### PR TITLE
[Fix] #19 JWT 토큰 권한 체크 오류 해결 

### DIFF
--- a/core/src/main/java/com/foodielog/server/_core/security/SecurityConfig.java
+++ b/core/src/main/java/com/foodielog/server/_core/security/SecurityConfig.java
@@ -73,8 +73,8 @@ public class SecurityConfig {
 		http.authorizeRequests(
 			// '/api' 로 시작 하는 url 은 로그인 필요
 			authorize -> authorize.antMatchers("/auth/**").permitAll()    // 누구나 접근 가능
-				.antMatchers("/api/**").hasAnyRole("USER", "ADMIN")
-				.antMatchers("/admin/**").hasRole("ADMIN")
+				.antMatchers("/api/**").hasAnyAuthority("USER", "ADMIN")
+				.antMatchers("/admin/**").hasAuthority("ADMIN")
 				.anyRequest().authenticated()
 		);
 


### PR DESCRIPTION
## 요약
로그인 후 토큰으로 권한 체크안 안되는 현상 발견
-> hasRole() 의  'ROLE_' 접두어 때문에 발생한 오류

DB에 저장되는 'USER', 'ADMIN' 과의 통일성을 위해
hasRole() 대신 'ROLE_' 붙이지 않는 hasAuthority() 사용


## 작업 내용
- [X] SecurityConfig에서 url 권한 설정 부분 수정

## 참고 사항
### hasRole()의 경우 rolePrefix을 붙여서 검사함 
![image](https://github.com/FoodieLog/foodie-log-server/assets/65496092/20496583-e411-4aff-9f49-b786b3a153eb)
![image](https://github.com/FoodieLog/foodie-log-server/assets/65496092/2578de45-1c98-41ec-80c9-5518e057e191)
![image](https://github.com/FoodieLog/foodie-log-server/assets/65496092/b35c7d7f-0e9b-42fa-9efe-e8639189772d)

### hasAuthority()의 경우 rolePrefix를 붙이지 않음
![image](https://github.com/FoodieLog/foodie-log-server/assets/65496092/e0c1cbe0-b594-45e6-9c53-d477174b3eab)
![image](https://github.com/FoodieLog/foodie-log-server/assets/65496092/fada6b56-e09a-41b6-9574-165a6a6f2829)

## 관련 이슈
Close #19
