### PR TITLE
[Feat] #22 카카오 로그인&회원가입 구현

### DIFF
--- a/application/src/main/java/com/foodielog/application/user/controller/UserAuthController.java
+++ b/application/src/main/java/com/foodielog/application/user/controller/UserAuthController.java
@@ -60,9 +60,7 @@ public class UserAuthController {
 		log.info("쿠키 생성 완료: " + cookie.toString());
 		headers.add(HttpHeaders.SET_COOKIE, cookie.toString());
 
-		// @Todo 리다이렉트 url 설정(프론트 서버로 리다이렉트?)
-		//headers.add(HttpHeaders.LOCATION, "https://localhost:8080/api/hi");
 
-		return new ResponseEntity<>(ApiUtils.success(response), headers, HttpStatus.FOUND);
+		return new ResponseEntity<>(ApiUtils.success(response), headers, HttpStatus.OK);
 	}
 }

--- a/application/src/main/java/com/foodielog/application/user/controller/UserAuthController.java
+++ b/application/src/main/java/com/foodielog/application/user/controller/UserAuthController.java
@@ -36,10 +36,7 @@ public class UserAuthController {
 	public ResponseEntity<?> login(@RequestBody @Valid UserRequest.LoginDTO loginDTO, Errors errors) {
 		UserResponse.LoginDTO response = userService.login(loginDTO);
 
-		HttpHeaders headers = new HttpHeaders();
-		ResponseCookie cookie = CookieUtil.getRefreshTokenCookie(response.getRefreshToken());
-		log.info("쿠키 생성 완료: " + cookie.toString());
-		headers.add(HttpHeaders.SET_COOKIE, cookie.toString());
+		HttpHeaders headers = getCookieHeaders(response);
 
 		return new ResponseEntity<>(ApiUtils.success(response), headers, HttpStatus.OK);
 	}
@@ -55,12 +52,16 @@ public class UserAuthController {
 
 		UserResponse.LoginDTO response = oauthUserService.kakaoLogin(code);
 
+		HttpHeaders headers = getCookieHeaders(response);
+
+		return new ResponseEntity<>(ApiUtils.success(response), headers, HttpStatus.OK);
+	}
+
+	private static HttpHeaders getCookieHeaders(UserResponse.LoginDTO response) {
 		HttpHeaders headers = new HttpHeaders();
 		ResponseCookie cookie = CookieUtil.getRefreshTokenCookie(response.getRefreshToken());
 		log.info("쿠키 생성 완료: " + cookie.toString());
 		headers.add(HttpHeaders.SET_COOKIE, cookie.toString());
-
-
-		return new ResponseEntity<>(ApiUtils.success(response), headers, HttpStatus.OK);
+		return headers;
 	}
 }

--- a/application/src/main/java/com/foodielog/application/user/controller/UserAuthController.java
+++ b/application/src/main/java/com/foodielog/application/user/controller/UserAuthController.java
@@ -41,8 +41,8 @@ public class UserAuthController {
 		return new ResponseEntity<>(ApiUtils.success(response), headers, HttpStatus.OK);
 	}
 
-	@GetMapping("/kakao/callback")
-	public ResponseEntity<?> kakaoCalllback(String code) {
+	@GetMapping("/login/kakao")
+	public ResponseEntity<?> kakaoLogin(String code) {
 		log.info("kakao 인가 code : " + code);
 
 		if (code == null || code.isEmpty()) {

--- a/application/src/main/java/com/foodielog/application/user/controller/UserAuthController.java
+++ b/application/src/main/java/com/foodielog/application/user/controller/UserAuthController.java
@@ -21,6 +21,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import com.foodielog.application.user.service.UserService;
+import com.foodielog.server._core.util.CookieUtil;
+
 @Slf4j
 @RequiredArgsConstructor
 @RequestMapping("/auth")
@@ -33,8 +35,8 @@ public class UserAuthController {
 		UserResponse.LoginDTO response = userService.login(loginDTO);
 
 		HttpHeaders headers = new HttpHeaders();
-		ResponseCookie cookie = getRefreshTokenCookie(response.getRefreshToken());
-		log.info("쿠키 생성 완료: "+cookie.toString());
+		ResponseCookie cookie = CookieUtil.getRefreshTokenCookie(response.getRefreshToken());
+		log.info("쿠키 생성 완료: " + cookie.toString());
 		headers.add(HttpHeaders.SET_COOKIE, cookie.toString());
 
 		return new ResponseEntity<>(ApiUtils.success(response), headers, HttpStatus.OK);

--- a/application/src/main/java/com/foodielog/application/user/dto/KakaoDTO.java
+++ b/application/src/main/java/com/foodielog/application/user/dto/KakaoDTO.java
@@ -1,0 +1,32 @@
+package com.foodielog.application.user.dto;
+
+import lombok.Getter;
+
+public class KakaoDTO {
+
+	@Getter
+	public static class Token {
+		private String accessToken;
+		private String tokenType;
+		private String refreshToken;
+		private int expiresIn;
+		private String scope;
+		private int refreshTokenExpiresIn;
+	}
+
+	@Getter
+	public static class UserInfo {
+		private Long id;
+		private String connectedAt;
+		private KakaoAccount kakaoAccount;
+	}
+
+	@Getter
+	public static class KakaoAccount{
+		private Boolean hasEmail;
+		private Boolean emailNeedsAgreement; // 사용자 동의 여부
+		private Boolean isEmailValid; // 이메일 유효 여부. false인 경우 일부 마스킹(Masking)하여 제공(예: ka***@kakao.com)
+		private Boolean isEmailVerified; // 이메일 인증 여부. false인 경우 서비스에서 이메일이 올바르게 전송되지 않을 수 있음
+		private String email;
+	}
+}

--- a/application/src/main/java/com/foodielog/application/user/service/OauthUserService.java
+++ b/application/src/main/java/com/foodielog/application/user/service/OauthUserService.java
@@ -118,8 +118,6 @@ public class OauthUserService {
 			throw new Exception500(userInfoResponse.getBody());
 		}
 
-		log.info(userInfoResponse.getBody());
-
 		ObjectMapper om = new ObjectMapper();
 		om.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
 		try {

--- a/application/src/main/java/com/foodielog/application/user/service/OauthUserService.java
+++ b/application/src/main/java/com/foodielog/application/user/service/OauthUserService.java
@@ -1,0 +1,135 @@
+package com.foodielog.application.user.service;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import javax.transaction.Transactional;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.foodielog.server._core.error.exception.Exception401;
+import com.foodielog.server._core.security.jwt.JwtTokenProvider;
+import com.foodielog.application.user.dto.KakaoDTO;
+import com.foodielog.application.user.dto.UserResponse;
+import com.foodielog.server._core.error.exception.Exception500;
+import com.foodielog.server._core.util.Fetch;
+import com.foodielog.server.user.entity.User;
+import com.foodielog.server.user.repository.UserRepository;
+import com.foodielog.server.user.type.ProviderType;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class OauthUserService {
+	@Value("${kakao.api.key}")
+	private String KAKAO_API_KEY;
+
+	@Value("${kakao.login.grant-type}")
+	private String KAKAO_GRANT_TYPE;
+
+	@Value("${kakao.login.redirect-uri}")
+	private String KAKAO_REDIRECT_URI;
+
+	@Value("${kakao.login.token-uri}")
+	private String KAKAO_TOKEN_URI;
+
+	@Value("${kakao.login.user-info-uri}")
+	private String KAKAO_USER_INFO_URI;
+
+	private final PasswordEncoder passwordEncoder;
+	private final JwtTokenProvider jwtTokenProvider;
+	private final UserRepository userRepository;
+
+	@Transactional
+	public UserResponse.LoginDTO kakaoLogin(String code) {
+		KakaoDTO.Token kakaoAccessToken = getKakaoAccessToken(code);
+		KakaoDTO.UserInfo kakaoUserInfo = getKakaoUserInfo(kakaoAccessToken.getAccessToken());
+		KakaoDTO.KakaoAccount kakaoAccount = kakaoUserInfo.getKakaoAccount();
+
+		if(!kakaoAccount.getIsEmailValid()){
+			throw new Exception401("로그인 불가: 카카오 계정에 연결된 이메일이 유효하지 않습니다.");
+		}
+
+		Optional<User> userOptional = userRepository.findByEmail(kakaoAccount.getEmail());
+
+		User loginUser;
+		// 회원 정보가 없으면 회원가입
+		if(userOptional.isEmpty()){
+			String encodedRandomPassword = passwordEncoder.encode(UUID.randomUUID().toString());
+			User user = User.createSocialUser(kakaoUserInfo.getId(),kakaoAccount.getEmail(), encodedRandomPassword,
+				ProviderType.KAKAO);
+
+			loginUser=userRepository.save(user);
+		}else{
+			loginUser=userOptional.get();
+		}
+
+		String accessToken = jwtTokenProvider.createAccessToken(loginUser);
+		String refreshToken = jwtTokenProvider.createRefreshToken(loginUser);
+
+		log.info("kakao 엑세스 토큰 생성 완료: "+accessToken);
+		log.info("kakao 리프레시 토큰 생성 완료: "+refreshToken);
+
+		return new UserResponse.LoginDTO(loginUser, accessToken, refreshToken);
+	}
+
+	public KakaoDTO.Token getKakaoAccessToken(String code) {
+		MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+		body.add("grant_type", KAKAO_GRANT_TYPE);
+		body.add("client_id", KAKAO_API_KEY);
+		body.add("redirect_uri", KAKAO_REDIRECT_URI);
+		body.add("code", code);
+
+		ResponseEntity<String> tokenResponse = Fetch.kakaoTokenRequest(KAKAO_TOKEN_URI, HttpMethod.POST, body);
+
+		if(!tokenResponse.getStatusCode().equals(HttpStatus.OK)){
+			throw new Exception500(tokenResponse.getBody());
+		}
+
+		ObjectMapper om = new ObjectMapper();
+		om.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
+		try {
+			KakaoDTO.Token kakaoToken = om.readValue(tokenResponse.getBody(), KakaoDTO.Token.class);
+
+			log.info("kakao access_token : " + kakaoToken.getAccessToken());
+			return kakaoToken;
+		} catch (JsonProcessingException e) {
+			throw new Exception500("Kakao 로그인(1): Json 파싱 오류");
+		}
+	}
+
+	public KakaoDTO.UserInfo getKakaoUserInfo(String token) {
+		ResponseEntity<String> userInfoResponse = Fetch.kakaoUserInfoRequest(KAKAO_USER_INFO_URI, HttpMethod.POST, token);
+
+		if(!userInfoResponse.getStatusCode().equals(HttpStatus.OK)){
+			throw new Exception500(userInfoResponse.getBody());
+		}
+
+		log.info(userInfoResponse.getBody());
+
+		ObjectMapper om = new ObjectMapper();
+		om.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
+		try {
+			KakaoDTO.UserInfo userInfo = om.readValue(userInfoResponse.getBody(), KakaoDTO.UserInfo.class);
+
+			log.info("kakao email : " + userInfo.getKakaoAccount().getEmail());
+			return userInfo;
+		} catch (JsonProcessingException e) {
+			e.printStackTrace();
+			throw new Exception500("Kakao 로그인(2): Json 파싱 오류");
+		}
+	}
+}

--- a/application/src/main/resources/application-api.yml
+++ b/application/src/main/resources/application-api.yml
@@ -1,0 +1,8 @@
+kakao:
+  login:
+    redirect-uri: "http://localhost:8080/auth/kakao/callback"
+    grant-type: "authorization_code"
+    authorization-uri: "https://kauth.kakao.com/oauth/authorize"
+    token-uri: "https://kauth.kakao.com/oauth/token"
+    user-info-uri: "https://kapi.kakao.com/v2/user/me"
+    user-name-attribute: "id"

--- a/application/src/main/resources/application.yml
+++ b/application/src/main/resources/application.yml
@@ -7,7 +7,7 @@ server:
 
 spring:
   config:
-    import: env.yml
+    import: env.yml, application-api.yml
   datasource:
     url: jdbc:h2:mem:test;MODE=MySQL
     driver-class-name: org.h2.Driver

--- a/core/src/main/java/com/foodielog/server/_core/security/SecurityConfig.java
+++ b/core/src/main/java/com/foodielog/server/_core/security/SecurityConfig.java
@@ -71,8 +71,9 @@ public class SecurityConfig {
 
 		// 11. 인증, 권한 필터 설정
 		http.authorizeRequests(
-			// '/api' 로 시작 하는 url 은 로그인 필요
-			authorize -> authorize.antMatchers("/auth/**").permitAll()    // 누구나 접근 가능
+			// '/api' 로 시작 하는 url 은 로그인 필요제
+			// @Todo "/h2-console/**" 접근은 개발 시에만 열어 두고 배포시 제거
+			authorize -> authorize.antMatchers("/auth/**","/h2-console/**").permitAll()    // 누구나 접근 가능
 				.antMatchers("/api/**").hasAnyAuthority("USER", "ADMIN")
 				.antMatchers("/admin/**").hasAuthority("ADMIN")
 				.anyRequest().authenticated()

--- a/core/src/main/java/com/foodielog/server/_core/util/CookieUtil.java
+++ b/core/src/main/java/com/foodielog/server/_core/util/CookieUtil.java
@@ -1,0 +1,17 @@
+package com.foodielog.server._core.util;
+
+import org.springframework.http.ResponseCookie;
+
+import com.foodielog.server._core.security.jwt.JwtTokenProvider;
+
+public class CookieUtil {
+	public static ResponseCookie getRefreshTokenCookie(String refreshToken) {
+		return ResponseCookie.from("refreshToken", refreshToken)
+			.maxAge(JwtTokenProvider.EXP_REFRESH)
+			.path("/")
+			.secure(true) // https 환경에서만 쿠키가 발동
+			.sameSite("None") // 크로스 사이트에도 전송 가능
+			.httpOnly(true) // 브라우저에서 접근 불가
+			.build();
+	}
+}

--- a/core/src/main/java/com/foodielog/server/_core/util/Fetch.java
+++ b/core/src/main/java/com/foodielog/server/_core/util/Fetch.java
@@ -1,0 +1,32 @@
+package com.foodielog.server._core.util;
+
+import org.springframework.http.*;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+public class Fetch {
+    public static ResponseEntity<String> kakaoTokenRequest(String url, HttpMethod method, MultiValueMap<String, String> body){
+        RestTemplate rt = new RestTemplate();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        HttpEntity<?> httpEntity = new HttpEntity<>(body, headers);
+
+        ResponseEntity<String> responseEntity = rt.exchange(url, method, httpEntity, String.class);
+        return responseEntity;
+    }
+
+    public static ResponseEntity<String> kakaoUserInfoRequest(String url, HttpMethod method, String accessToken){
+        RestTemplate rt = new RestTemplate();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.setBearerAuth(accessToken);
+
+        HttpEntity<?> httpEntity = new HttpEntity<>(headers);
+
+        ResponseEntity<String> responseEntity = rt.exchange(url, method, httpEntity, String.class);
+        return responseEntity;
+    }
+}

--- a/core/src/main/java/com/foodielog/server/user/entity/User.java
+++ b/core/src/main/java/com/foodielog/server/user/entity/User.java
@@ -79,4 +79,13 @@ public class User {
 
 	@UpdateTimestamp
 	private Timestamp updatedAt;
+
+	public static User createSocialUser(Long id, String email, String password, ProviderType provider) {
+		User user = new User();
+		user.email = email;
+		user.password = password;
+		user.provider = provider;
+		user.nickName = provider+id.toString();
+		return user;
+	}
 }

--- a/core/src/main/java/com/foodielog/server/user/repository/UserRepository.java
+++ b/core/src/main/java/com/foodielog/server/user/repository/UserRepository.java
@@ -8,4 +8,6 @@ import com.foodielog.server.user.entity.User;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findByEmail(String email);
+
+	Boolean existsByEmail(String email);
 }


### PR DESCRIPTION
## 요약
카카오 로그인&회원가입 구현

## 작업 내용
 - [X] 카카오 회원가입(이메일 정보 받아오기)
 - [ ] 카카오 회원가입(이용 동의)
- [X] 카카오 로그인

## 참고 사항
1. 프론트 에서도 카카오 api 연결 필요 -> 추후 담당자에서 설명
2. 카카오 로그인과 동시에 회원가입 시, 닉네임 'kakao{ 사용자의 카카오 아이디(num) }'로 임의 설정
-> user(entity)의 nickName이 not null이기 때문
3. 카카오 간편 회원가입(우리 서비스 이용 약관 동의)는 비즈앱+비즈채널만 가능하여 검수 요청 함

## 관련 이슈
Close #22
