### PR TITLE
[Feat] #24 자체 회원가입 기능

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'

--- a/application/src/main/java/com/foodielog/application/_core/smtp/MailService.java
+++ b/application/src/main/java/com/foodielog/application/_core/smtp/MailService.java
@@ -1,0 +1,41 @@
+package com.foodielog.application._core.smtp;
+
+import com.foodielog.server._core.error.exception.Exception500;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class MailService {
+    private final JavaMailSender emailSender;
+
+    public void sendEmail(String toEmail, String title, String text) {
+        SimpleMailMessage emailForm = createEmailForm(toEmail, title, text);
+        try {
+            emailSender.send(emailForm);
+        } catch (RuntimeException e) {
+            log.debug("MailService.sendEmail exception occur toEmail: {}, " +
+                    "title: {}, text: {}", toEmail, title, text);
+            throw new Exception500("서버 에러 #E2");
+        }
+    }
+
+    // 발신할 이메일 데이터 세팅
+    private SimpleMailMessage createEmailForm(String toEmail, String title, String text) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(toEmail);
+        message.setSubject(title);
+        message.setText(text);
+
+        return message;
+    }
+}
+
+

--- a/application/src/main/java/com/foodielog/application/_core/smtp/MailService.java
+++ b/application/src/main/java/com/foodielog/application/_core/smtp/MailService.java
@@ -7,11 +7,8 @@ import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 
-import javax.transaction.Transactional;
-
 @Slf4j
 @RequiredArgsConstructor
-@Transactional
 @Service
 public class MailService {
     private final JavaMailSender emailSender;

--- a/application/src/main/java/com/foodielog/application/_core/smtp/SMTPConfig.java
+++ b/application/src/main/java/com/foodielog/application/_core/smtp/SMTPConfig.java
@@ -1,0 +1,67 @@
+package com.foodielog.application._core.smtp;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class SMTPConfig {
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Value("${spring.mail.properties.mail.smtp.auth}")
+    private boolean auth;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.enable}")
+    private boolean starttlsEnable;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.required}")
+    private boolean starttlsRequired;
+
+    @Value("${spring.mail.properties.mail.smtp.connectiontimeout}")
+    private int connectionTimeout;
+
+    @Value("${spring.mail.properties.mail.smtp.timeout}")
+    private int timeout;
+
+    @Value("${spring.mail.properties.mail.smtp.writetimeout}")
+    private int writeTimeout;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+        mailSender.setDefaultEncoding("UTF-8");
+        mailSender.setJavaMailProperties(getMailProperties());
+
+        return mailSender;
+    }
+
+    private Properties getMailProperties() {
+        Properties properties = new Properties();
+        properties.put("mail.smtp.auth", auth);
+        properties.put("mail.smtp.starttls.enable", starttlsEnable);
+        properties.put("mail.smtp.starttls.required", starttlsRequired);
+        properties.put("mail.smtp.connectiontimeout", connectionTimeout);
+        properties.put("mail.smtp.timeout", timeout);
+        properties.put("mail.smtp.writetimeout", writeTimeout);
+
+        return properties;
+    }
+}

--- a/application/src/main/java/com/foodielog/application/user/controller/UserAuthController.java
+++ b/application/src/main/java/com/foodielog/application/user/controller/UserAuthController.java
@@ -5,7 +5,7 @@ import com.foodielog.application.user.dto.UserResponse;
 import com.foodielog.application.user.dto.response.SendCodeDTO;
 import com.foodielog.application.user.dto.response.VerifiedCodeDTO;
 import com.foodielog.application.user.service.OauthUserService;
-import com.foodielog.application.user.service.UserService;
+import com.foodielog.application.user.service.UserAuthService;
 import com.foodielog.server._core.customValid.valid.ValidNickName;
 import com.foodielog.server._core.util.ApiUtils;
 import com.foodielog.server._core.util.CookieUtil;
@@ -29,12 +29,12 @@ import javax.validation.constraints.Size;
 @RequestMapping("/auth")
 @RestController
 public class UserAuthController {
-    private final UserService userService;
+    private final UserAuthService userAuthService;
     private final OauthUserService oauthUserService;
 
     @GetMapping("/exists/email")
     public ResponseEntity<?> checkExistsEmail(@RequestParam @Email String input) {
-        Boolean isExists = userService.checkExistsEmail(input);
+        Boolean isExists = userAuthService.checkExistsEmail(input);
         UserResponse.ExistsEmailDTO response = new UserResponse.ExistsEmailDTO(input);
 
         HttpStatus httpStatus = isExists ? HttpStatus.CONFLICT : HttpStatus.OK;
@@ -43,7 +43,7 @@ public class UserAuthController {
 
     @GetMapping("/exists/nickname")
     public ResponseEntity<?> checkExistsNickName(@RequestParam @ValidNickName String input) {
-        Boolean isExists = userService.checkExistsNickName(input);
+        Boolean isExists = userAuthService.checkExistsNickName(input);
         UserResponse.ExistsNickNameDTO response = new UserResponse.ExistsNickNameDTO(input);
 
         HttpStatus httpStatus = isExists ? HttpStatus.CONFLICT : HttpStatus.OK;
@@ -52,7 +52,7 @@ public class UserAuthController {
 
     @GetMapping("/email/code-requests/signup")
     public ResponseEntity<?> sendCode(@RequestParam @Email String email) {
-        SendCodeDTO.Response response = userService.sendCodeForSignUp(email);
+        SendCodeDTO.Response response = userAuthService.sendCodeForSignUp(email);
 
         return new ResponseEntity<>(ApiUtils.success(response, HttpStatus.OK), HttpStatus.OK);
     }
@@ -61,7 +61,7 @@ public class UserAuthController {
     public ResponseEntity<?> verificationCode(@RequestParam @Email String email,
                                               @RequestParam @Size(min = 4, max = 4) String code
     ) {
-        VerifiedCodeDTO.Response response = userService.verifiedCode(email, code);
+        VerifiedCodeDTO.Response response = userAuthService.verifiedCode(email, code);
         HttpStatus httpStatus = response.getIsVerified() ? HttpStatus.OK : HttpStatus.UNAUTHORIZED;
 
         return new ResponseEntity<>(ApiUtils.success(response, httpStatus), httpStatus);
@@ -69,7 +69,7 @@ public class UserAuthController {
 
     @PostMapping("/login")
     public ResponseEntity<?> login(@RequestBody @Valid UserRequest.LoginDTO loginDTO, Errors errors) {
-        UserResponse.LoginDTO response = userService.login(loginDTO);
+        UserResponse.LoginDTO response = userAuthService.login(loginDTO);
 
         HttpHeaders headers = getCookieHeaders(response);
 

--- a/application/src/main/java/com/foodielog/application/user/controller/UserAuthController.java
+++ b/application/src/main/java/com/foodielog/application/user/controller/UserAuthController.java
@@ -4,8 +4,8 @@ import com.foodielog.application.user.dto.UserRequest;
 import com.foodielog.application.user.dto.UserResponse;
 import com.foodielog.application.user.dto.response.SendCodeDTO;
 import com.foodielog.application.user.dto.response.VerifiedCodeDTO;
-import com.foodielog.application.user.service.OauthUserService;
 import com.foodielog.application.user.service.UserAuthService;
+import com.foodielog.application.user.service.UserOauthService;
 import com.foodielog.server._core.customValid.valid.ValidNickName;
 import com.foodielog.server._core.util.ApiUtils;
 import com.foodielog.server._core.util.CookieUtil;
@@ -30,7 +30,7 @@ import javax.validation.constraints.Size;
 @RestController
 public class UserAuthController {
     private final UserAuthService userAuthService;
-    private final OauthUserService oauthUserService;
+    private final UserOauthService oauthUserService;
 
     @GetMapping("/exists/email")
     public ResponseEntity<?> checkExistsEmail(@RequestParam @Email String input) {
@@ -58,8 +58,9 @@ public class UserAuthController {
     }
 
     @GetMapping("/email/verification")
-    public ResponseEntity<?> verificationCode(@RequestParam @Email String email,
-                                              @RequestParam @Size(min = 4, max = 4) String code
+    public ResponseEntity<?> verificationCode(
+            @RequestParam @Email String email,
+            @RequestParam @Size(min = 4, max = 4) String code
     ) {
         VerifiedCodeDTO.Response response = userAuthService.verifiedCode(email, code);
         HttpStatus httpStatus = response.getIsVerified() ? HttpStatus.OK : HttpStatus.UNAUTHORIZED;

--- a/application/src/main/java/com/foodielog/application/user/controller/UserAuthController.java
+++ b/application/src/main/java/com/foodielog/application/user/controller/UserAuthController.java
@@ -32,6 +32,7 @@ public class UserAuthController {
     private final UserAuthService userAuthService;
     private final UserOauthService oauthUserService;
 
+    /* 회원 가입 */
     @GetMapping("/exists/email")
     public ResponseEntity<?> checkExistsEmail(@RequestParam @Email String input) {
         Boolean isExists = userAuthService.checkExistsEmail(input);
@@ -41,15 +42,7 @@ public class UserAuthController {
         return new ResponseEntity<>(ApiUtils.success(response, httpStatus), httpStatus);
     }
 
-    @GetMapping("/exists/nickname")
-    public ResponseEntity<?> checkExistsNickName(@RequestParam @ValidNickName String input) {
-        Boolean isExists = userAuthService.checkExistsNickName(input);
-        UserResponse.ExistsNickNameDTO response = new UserResponse.ExistsNickNameDTO(input);
-
-        HttpStatus httpStatus = isExists ? HttpStatus.CONFLICT : HttpStatus.OK;
-        return new ResponseEntity<>(ApiUtils.success(response, httpStatus), httpStatus);
-    }
-
+    /* 이메일 인증 */
     @GetMapping("/email/code-requests/signup")
     public ResponseEntity<?> sendCode(@RequestParam @Email String email) {
         SendCodeDTO.Response response = userAuthService.sendCodeForSignUp(email);
@@ -68,6 +61,7 @@ public class UserAuthController {
         return new ResponseEntity<>(ApiUtils.success(response, httpStatus), httpStatus);
     }
 
+    /* 로그인 */
     @PostMapping("/login")
     public ResponseEntity<?> login(@RequestBody @Valid UserRequest.LoginDTO loginDTO, Errors errors) {
         UserResponse.LoginDTO response = userAuthService.login(loginDTO);
@@ -86,6 +80,16 @@ public class UserAuthController {
         HttpHeaders headers = getCookieHeaders(response);
 
         return new ResponseEntity<>(ApiUtils.success(response, HttpStatus.OK), headers, HttpStatus.OK);
+    }
+
+    /* 프로필 설정 */
+    @GetMapping("/exists/nickname")
+    public ResponseEntity<?> checkExistsNickName(@RequestParam @ValidNickName String input) {
+        Boolean isExists = userAuthService.checkExistsNickName(input);
+        UserResponse.ExistsNickNameDTO response = new UserResponse.ExistsNickNameDTO(input);
+
+        HttpStatus httpStatus = isExists ? HttpStatus.CONFLICT : HttpStatus.OK;
+        return new ResponseEntity<>(ApiUtils.success(response, httpStatus), httpStatus);
     }
 
     private static HttpHeaders getCookieHeaders(UserResponse.LoginDTO response) {

--- a/application/src/main/java/com/foodielog/application/user/controller/UserAuthController.java
+++ b/application/src/main/java/com/foodielog/application/user/controller/UserAuthController.java
@@ -1,5 +1,6 @@
 package com.foodielog.application.user.controller;
 
+import com.foodielog.application.user.dto.SignUpDTO;
 import com.foodielog.application.user.dto.UserRequest;
 import com.foodielog.application.user.dto.UserResponse;
 import com.foodielog.application.user.dto.response.SendCodeDTO;
@@ -18,6 +19,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.Errors;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Email;
@@ -40,6 +42,17 @@ public class UserAuthController {
 
         HttpStatus httpStatus = isExists ? HttpStatus.CONFLICT : HttpStatus.OK;
         return new ResponseEntity<>(ApiUtils.success(response, httpStatus), httpStatus);
+    }
+
+    @PostMapping("/signup")
+    public ResponseEntity<?> signUp(
+            @RequestPart(value = "content") @Valid SignUpDTO.Request request,
+            @RequestPart(value = "file") MultipartFile file,
+            Errors errors
+    ) {
+        SignUpDTO.Response response = userAuthService.signUp(request, file);
+
+        return new ResponseEntity<>(ApiUtils.success(response, HttpStatus.OK), HttpStatus.OK);
     }
 
     /* 이메일 인증 */

--- a/application/src/main/java/com/foodielog/application/user/controller/UserAuthController.java
+++ b/application/src/main/java/com/foodielog/application/user/controller/UserAuthController.java
@@ -2,6 +2,8 @@ package com.foodielog.application.user.controller;
 
 import com.foodielog.application.user.dto.UserRequest;
 import com.foodielog.application.user.dto.UserResponse;
+import com.foodielog.application.user.dto.response.SendCodeDTO;
+import com.foodielog.application.user.dto.response.VerifiedCodeDTO;
 import com.foodielog.application.user.service.OauthUserService;
 import com.foodielog.application.user.service.UserService;
 import com.foodielog.server._core.customValid.valid.ValidNickName;
@@ -19,6 +21,7 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Email;
+import javax.validation.constraints.Size;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -44,6 +47,23 @@ public class UserAuthController {
         UserResponse.ExistsNickNameDTO response = new UserResponse.ExistsNickNameDTO(input);
 
         HttpStatus httpStatus = isExists ? HttpStatus.CONFLICT : HttpStatus.OK;
+        return new ResponseEntity<>(ApiUtils.success(response, httpStatus), httpStatus);
+    }
+
+    @GetMapping("/email/code-requests/signup")
+    public ResponseEntity<?> sendCode(@RequestParam @Email String email) {
+        SendCodeDTO.Response response = userService.sendCodeForSignUp(email);
+
+        return new ResponseEntity<>(ApiUtils.success(response, HttpStatus.OK), HttpStatus.OK);
+    }
+
+    @GetMapping("/email/verification")
+    public ResponseEntity<?> verificationCode(@RequestParam @Email String email,
+                                              @RequestParam @Size(min = 4, max = 4) String code
+    ) {
+        VerifiedCodeDTO.Response response = userService.verifiedCode(email, code);
+        HttpStatus httpStatus = response.getIsVerified() ? HttpStatus.OK : HttpStatus.UNAUTHORIZED;
+
         return new ResponseEntity<>(ApiUtils.success(response, httpStatus), httpStatus);
     }
 

--- a/application/src/main/java/com/foodielog/application/user/controller/UserAuthController.java
+++ b/application/src/main/java/com/foodielog/application/user/controller/UserAuthController.java
@@ -4,6 +4,7 @@ import com.foodielog.application.user.dto.UserRequest;
 import com.foodielog.application.user.dto.UserResponse;
 import com.foodielog.application.user.service.OauthUserService;
 import com.foodielog.application.user.service.UserService;
+import com.foodielog.server._core.customValid.valid.ValidNickName;
 import com.foodielog.server._core.util.ApiUtils;
 import com.foodielog.server._core.util.CookieUtil;
 import lombok.RequiredArgsConstructor;
@@ -13,17 +14,38 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.Errors;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import javax.validation.constraints.Email;
 
 @Slf4j
 @RequiredArgsConstructor
+@Validated
 @RequestMapping("/auth")
 @RestController
 public class UserAuthController {
     private final UserService userService;
     private final OauthUserService oauthUserService;
+
+    @GetMapping("/exists/email")
+    public ResponseEntity<?> checkExistsEmail(@RequestParam @Email String input) {
+        Boolean isExists = userService.checkExistsEmail(input);
+        UserResponse.ExistsEmailDTO response = new UserResponse.ExistsEmailDTO(input);
+
+        HttpStatus httpStatus = isExists ? HttpStatus.CONFLICT : HttpStatus.OK;
+        return new ResponseEntity<>(ApiUtils.success(response, httpStatus), httpStatus);
+    }
+
+    @GetMapping("/exists/nickname")
+    public ResponseEntity<?> checkExistsNickName(@RequestParam @ValidNickName String input) {
+        Boolean isExists = userService.checkExistsNickName(input);
+        UserResponse.ExistsNickNameDTO response = new UserResponse.ExistsNickNameDTO(input);
+
+        HttpStatus httpStatus = isExists ? HttpStatus.CONFLICT : HttpStatus.OK;
+        return new ResponseEntity<>(ApiUtils.success(response, httpStatus), httpStatus);
+    }
 
     @PostMapping("/login")
     public ResponseEntity<?> login(@RequestBody @Valid UserRequest.LoginDTO loginDTO, Errors errors) {
@@ -35,13 +57,8 @@ public class UserAuthController {
     }
 
     @GetMapping("/login/kakao")
-    public ResponseEntity<?> kakaoLogin(String code) {
+    public ResponseEntity<?> kakaoLogin(@RequestParam String code) {
         log.info("kakao 인가 code : " + code);
-
-        if (code == null || code.isEmpty()) {
-            return new ResponseEntity<>(ApiUtils.error("카카오 로그인에 실패했습니다.", HttpStatus.BAD_REQUEST),
-                    HttpStatus.BAD_REQUEST);
-        }
 
         UserResponse.LoginDTO response = oauthUserService.kakaoLogin(code);
 

--- a/application/src/main/java/com/foodielog/application/user/dto/SignUpDTO.java
+++ b/application/src/main/java/com/foodielog/application/user/dto/SignUpDTO.java
@@ -1,0 +1,39 @@
+package com.foodielog.application.user.dto;
+
+import com.foodielog.server._core.customValid.valid.ValidNickName;
+import com.foodielog.server._core.customValid.valid.ValidPassWord;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.Email;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class SignUpDTO {
+    @Getter
+    public static class Request {
+        @Email
+        private String email;
+
+        @ValidPassWord
+        private String password;
+
+        @ValidNickName
+        private String nickName;
+
+        private String aboutMe;
+    }
+
+    @Getter
+    public static class Response {
+        private final String email;
+        private final String nickName;
+        private final String profileImageUrl;
+
+        public Response(String email, String nickName, String profileImageUrl) {
+            this.email = email;
+            this.nickName = nickName;
+            this.profileImageUrl = profileImageUrl;
+        }
+    }
+}

--- a/application/src/main/java/com/foodielog/application/user/dto/UserResponse.java
+++ b/application/src/main/java/com/foodielog/application/user/dto/UserResponse.java
@@ -1,28 +1,45 @@
 package com.foodielog.application.user.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.foodielog.server.feed.entity.Feed;
 import com.foodielog.server.user.entity.User;
-
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-import java.util.List;
-
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class UserResponse {
-	@Getter
-	public static class LoginDTO {
-		private String nickName;
-		private String profileImageUrl;
-		private String accessToken;
+    @Getter
+    public static class ExistsEmailDTO {
+        private final String email;
 
-		@JsonIgnore
-		private String refreshToken;
+        public ExistsEmailDTO(String email) {
+            this.email = email;
+        }
+    }
 
-		public LoginDTO(User user, String accessToken, String refreshToken) {
-			this.nickName = user.getNickName();
-			this.profileImageUrl = user.getProfileImageUrl();
-			this.accessToken = accessToken;
-			this.refreshToken = refreshToken;
-		}
-	}
+    @Getter
+    public static class ExistsNickNameDTO {
+        private final String nickName;
+
+        public ExistsNickNameDTO(String nickName) {
+            this.nickName = nickName;
+        }
+    }
+
+    @Getter
+    public static class LoginDTO {
+        private final String nickName;
+        private final String profileImageUrl;
+        private final String accessToken;
+
+        @JsonIgnore
+        private final String refreshToken;
+
+        public LoginDTO(User user, String accessToken, String refreshToken) {
+            this.nickName = user.getNickName();
+            this.profileImageUrl = user.getProfileImageUrl();
+            this.accessToken = accessToken;
+            this.refreshToken = refreshToken;
+        }
+    }
 }

--- a/application/src/main/java/com/foodielog/application/user/dto/response/SendCodeDTO.java
+++ b/application/src/main/java/com/foodielog/application/user/dto/response/SendCodeDTO.java
@@ -1,0 +1,15 @@
+package com.foodielog.application.user.dto.response;
+
+import lombok.Getter;
+
+
+public class SendCodeDTO {
+    @Getter
+    public static class Response {
+        private final String email;
+
+        public Response(String email) {
+            this.email = email;
+        }
+    }
+}

--- a/application/src/main/java/com/foodielog/application/user/dto/response/VerifiedCodeDTO.java
+++ b/application/src/main/java/com/foodielog/application/user/dto/response/VerifiedCodeDTO.java
@@ -1,0 +1,19 @@
+package com.foodielog.application.user.dto.response;
+
+import lombok.Getter;
+
+
+public class VerifiedCodeDTO {
+    @Getter
+    public static class Response {
+        private final String email;
+        private final String code;
+        private final Boolean isVerified;
+
+        public Response(String email, String code, Boolean isVerified) {
+            this.email = email;
+            this.code = code;
+            this.isVerified = isVerified;
+        }
+    }
+}

--- a/application/src/main/java/com/foodielog/application/user/service/UserAuthService.java
+++ b/application/src/main/java/com/foodielog/application/user/service/UserAuthService.java
@@ -1,0 +1,103 @@
+package com.foodielog.application.user.service;
+
+import com.foodielog.application._core.smtp.MailService;
+import com.foodielog.application.user.dto.UserRequest;
+import com.foodielog.application.user.dto.UserResponse;
+import com.foodielog.application.user.dto.response.SendCodeDTO;
+import com.foodielog.application.user.dto.response.VerifiedCodeDTO;
+import com.foodielog.server._core.error.ErrorMessage;
+import com.foodielog.server._core.error.exception.Exception400;
+import com.foodielog.server._core.error.exception.Exception500;
+import com.foodielog.server._core.redis.RedisService;
+import com.foodielog.server._core.security.jwt.JwtTokenProvider;
+import com.foodielog.server.user.entity.User;
+import com.foodielog.server.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class UserAuthService {
+    private static final String EMAIL_AUTH_CODE_PREFIX = "AuthCode ";
+
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final MailService mailService;
+    private final RedisService redisService;
+
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public Boolean checkExistsEmail(String input) {
+        return userRepository.existsByEmail(input);
+    }
+
+    @Transactional(readOnly = true)
+    public Boolean checkExistsNickName(String input) {
+        return userRepository.existsByNickName(input);
+    }
+
+    @Transactional(readOnly = true)
+    public UserResponse.LoginDTO login(UserRequest.LoginDTO loginDTO) {
+        User user = userRepository.findByEmail(loginDTO.getEmail())
+                .orElseThrow(() -> new Exception400("email", ErrorMessage.USER_NOT_FOUND));
+
+        if (!passwordEncoder.matches(loginDTO.getPassword(), user.getPassword())) {
+            throw new Exception400("password", ErrorMessage.PASSWORD_NOT_MATCH);
+        }
+
+        String accessToken = jwtTokenProvider.createAccessToken(user);
+        String refreshToken = jwtTokenProvider.createRefreshToken(user);
+
+        log.info("엑세스 토큰 생성 완료: " + accessToken);
+        log.info("리프레시 토큰 생성 완료: " + refreshToken);
+
+        return new UserResponse.LoginDTO(user, accessToken, refreshToken);
+    }
+
+    @Transactional
+    public SendCodeDTO.Response sendCodeForSignUp(String email) {
+        if (this.checkExistsEmail(email)) {
+            throw new Exception400("email", "이미 가입된 이메일 입니다");
+        }
+
+        // 이메일 전송
+        String title = "FoodieLog 회원 가입 이메일 인증 번호";
+        String authCode = this.createCode();
+        mailService.sendEmail(email, title, authCode);
+
+        // 이메일 인증 번호 Redis에 저장 ( key = "AuthCode " + Email / value = AuthCode )
+        redisService.setObjectByKey(EMAIL_AUTH_CODE_PREFIX + email, authCode, 3L, TimeUnit.MINUTES);
+
+        return new SendCodeDTO.Response(email);
+    }
+
+    private String createCode() {
+        try {
+            Random random = SecureRandom.getInstanceStrong();
+            int randomNumber = random.nextInt(9000) + 1000;
+
+            return Integer.toString(randomNumber);
+        } catch (NoSuchAlgorithmException e) {
+            log.debug("이메일 인증 코드 생성 오류");
+            throw new Exception500("서버 에러 #E1");
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public VerifiedCodeDTO.Response verifiedCode(String email, String code) {
+        String redisAuthCode = redisService.getObjectByKey(EMAIL_AUTH_CODE_PREFIX + email, String.class);
+        Boolean isVerified = redisAuthCode.equals(code);
+
+        return new VerifiedCodeDTO.Response(email, code, isVerified);
+    }
+}

--- a/application/src/main/java/com/foodielog/application/user/service/UserOauthService.java
+++ b/application/src/main/java/com/foodielog/application/user/service/UserOauthService.java
@@ -31,7 +31,7 @@ import java.util.UUID;
 @Slf4j
 @RequiredArgsConstructor
 @Service
-public class OauthUserService {
+public class UserOauthService {
     @Value("${kakao.api.key}")
     private String KAKAO_API_KEY;
 

--- a/application/src/main/java/com/foodielog/application/user/service/UserService.java
+++ b/application/src/main/java/com/foodielog/application/user/service/UserService.java
@@ -12,22 +12,13 @@ import com.foodielog.server.feed.repository.MediaRepository;
 import com.foodielog.server.reply.repository.ReplyRepository;
 import com.foodielog.server.restaurant.entity.Restaurant;
 import com.foodielog.server.restaurant.repository.RestaurantLikeRepository;
-import com.foodielog.server.restaurant.repository.RestaurantRepository;
-import com.foodielog.server.user.repository.FollowRepository;
-import org.springframework.data.domain.Pageable;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.stereotype.Service;
-
-import com.foodielog.application.user.dto.UserResponse;
-import com.foodielog.server._core.error.ErrorMessage;
-import com.foodielog.server._core.error.exception.Exception400;
-import com.foodielog.server._core.security.jwt.JwtTokenProvider;
-import com.foodielog.application.user.dto.UserRequest;
 import com.foodielog.server.user.entity.User;
+import com.foodielog.server.user.repository.FollowRepository;
 import com.foodielog.server.user.repository.UserRepository;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
@@ -38,102 +29,83 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @Service
 public class UserService {
-	private final PasswordEncoder passwordEncoder;
-	private final JwtTokenProvider jwtTokenProvider;
-	private final UserRepository userRepository;
-	private final FollowRepository followRepository;
-	private final FeedRepository feedRepository;
-	private final MediaRepository mediaRepository;
-	private final FeedLikeRepository feedLikeRepository;
-	private final RestaurantLikeRepository restaurantLikeRepository;
-	private final ReplyRepository replyRepository;
+    private final UserRepository userRepository;
+    private final FollowRepository followRepository;
+    private final FeedRepository feedRepository;
+    private final MediaRepository mediaRepository;
+    private final FeedLikeRepository feedLikeRepository;
+    private final RestaurantLikeRepository restaurantLikeRepository;
+    private final ReplyRepository replyRepository;
 
-	public UserResponse.LoginDTO login(UserRequest.LoginDTO loginDTO) {
-		User user = userRepository.findByEmail(loginDTO.getEmail())
-				.orElseThrow(() -> new Exception400("email", ErrorMessage.USER_NOT_FOUND));
+    @Transactional(readOnly = true)
+    public UserProfileDTO.Response getProfile(Long userId) {
+        User user = validationUserId(userId);
 
-		if (!passwordEncoder.matches(loginDTO.getPassword(), user.getPassword())) {
-			throw new Exception400("password", ErrorMessage.PASSWORD_NOT_MATCH);
-		}
+        Long feedCount = feedRepository.countByUser(user);
+        Long follower = followRepository.countByFollowedId(user);
+        Long following = followRepository.countByFollowingId(user);
 
-		String accessToken = jwtTokenProvider.createAccessToken(user);
-		String refreshToken = jwtTokenProvider.createRefreshToken(user);
+        return new UserProfileDTO.Response(user, feedCount, follower, following);
+    }
 
-		log.info("엑세스 토큰 생성 완료: "+accessToken);
-		log.info("리프레시 토큰 생성 완료: "+refreshToken);
+    @Transactional(readOnly = true)
+    public UserThumbnailDTO.Response getThumbnail(Long userId, Long feedId, Pageable pageable) {
+        User user = validationUserId(userId);
 
-		return new UserResponse.LoginDTO(user, accessToken, refreshToken);
-	}
+        List<Feed> feeds = feedRepository.getFeeds(user, feedId, pageable);
 
-	@Transactional(readOnly = true)
-	public UserProfileDTO.Response getProfile(Long userId) {
-		User user = validationUserId(userId);
+        List<UserThumbnailDTO.ThumbnailDTO> thumbnailDTO = feeds.stream()
+                .map(UserThumbnailDTO.ThumbnailDTO::new)
+                .collect(Collectors.toList());
 
-		Long feedCount = feedRepository.countByUser(user);
-		Long follower = followRepository.countByFollowedId(user);
-		Long following = followRepository.countByFollowingId(user);
+        return new UserThumbnailDTO.Response(thumbnailDTO);
+    }
 
-		return new UserProfileDTO.Response(user, feedCount, follower, following);
-	}
+    @Transactional(readOnly = true)
+    public UserFeedListDTO.Response getFeeds(Long userId, Long feedId, Pageable pageable) {
+        User user = validationUserId(userId);
 
-	@Transactional(readOnly = true)
-	public UserThumbnailDTO.Response getThumbnail(Long userId, Long feedId, Pageable pageable) {
-		User user = validationUserId(userId);
+        List<Feed> feeds = feedRepository.getFeeds(user, feedId, pageable);
 
-		List<Feed> feeds = feedRepository.getFeeds(user, feedId, pageable);
+        List<UserFeedListDTO.UserFeedsDTO> userFeedsDTOList = new ArrayList<>();
 
-		List<UserThumbnailDTO.ThumbnailDTO> thumbnailDTO = feeds.stream()
-				.map(UserThumbnailDTO.ThumbnailDTO::new)
-				.collect(Collectors.toList());
+        for (Feed feed : feeds) {
+            List<Media> mediaList = mediaRepository.findByFeed(feed);
 
-		return new UserThumbnailDTO.Response(thumbnailDTO);
-	}
+            List<UserFeedListDTO.FeedImageDTO> feedImages = getFeedImageDTO(mediaList);
+            UserFeedListDTO.FeedDTO feedDTO = getFeedDTO(feed, feedImages);
+            UserFeedListDTO.UserRestaurantDTO userRestaurantDTO = getUserRestaurantDTO(feed);
 
-	@Transactional(readOnly = true)
-	public UserFeedListDTO.Response getFeeds(Long userId, Long feedId, Pageable pageable) {
-		User user = validationUserId(userId);
+            boolean isFollowed = followRepository.existsByFollowedId(user);
+            boolean isLiked = restaurantLikeRepository.existsByUser(user);
 
-		List<Feed> feeds = feedRepository.getFeeds(user, feedId, pageable);
+            userFeedsDTOList.add(new UserFeedListDTO.UserFeedsDTO(feedDTO, userRestaurantDTO, isFollowed, isLiked));
+        }
 
-		List<UserFeedListDTO.UserFeedsDTO> userFeedsDTOList = new ArrayList<>();
+        return new UserFeedListDTO.Response(userFeedsDTOList);
+    }
 
-		for (Feed feed : feeds) {
-			List<Media> mediaList = mediaRepository.findByFeed(feed);
+    private UserFeedListDTO.UserRestaurantDTO getUserRestaurantDTO(Feed feed) {
+        Restaurant restaurant = feed.getRestaurant();
+        return new UserFeedListDTO.UserRestaurantDTO(restaurant);
+    }
 
-			List<UserFeedListDTO.FeedImageDTO> feedImages = getFeedImageDTO(mediaList);
-			UserFeedListDTO.FeedDTO feedDTO = getFeedDTO(feed, feedImages);
-			UserFeedListDTO.UserRestaurantDTO userRestaurantDTO = getUserRestaurantDTO(feed);
+    private UserFeedListDTO.FeedDTO getFeedDTO(Feed feed, List<UserFeedListDTO.FeedImageDTO> feedImages) {
+        Long likeCount = feedLikeRepository.countByFeed(feed);
+        Long replyCount = replyRepository.countByFeed(feed);
+        String share = null;
 
-			boolean isFollowed = followRepository.existsByFollowedId(user);
-			boolean isLiked = restaurantLikeRepository.existsByUser(user);
+        return new UserFeedListDTO.FeedDTO(feed, feedImages, likeCount, replyCount, share);
+    }
 
-			userFeedsDTOList.add(new UserFeedListDTO.UserFeedsDTO(feedDTO, userRestaurantDTO, isFollowed, isLiked));
-		}
+    private List<UserFeedListDTO.FeedImageDTO> getFeedImageDTO(List<Media> mediaList) {
+        return mediaList.stream()
+                .map(UserFeedListDTO.FeedImageDTO::new)
+                .collect(Collectors.toList());
+    }
 
-		return new UserFeedListDTO.Response(userFeedsDTOList);
-	}
-
-	private UserFeedListDTO.UserRestaurantDTO getUserRestaurantDTO(Feed feed) {
-		Restaurant restaurant = feed.getRestaurant();
-		return new UserFeedListDTO.UserRestaurantDTO(restaurant);
-	}
-
-	private UserFeedListDTO.FeedDTO getFeedDTO(Feed feed, List<UserFeedListDTO.FeedImageDTO> feedImages) {
-		Long likeCount = feedLikeRepository.countByFeed(feed);
-		Long replyCount = replyRepository.countByFeed(feed);
-		String share = null;
-
-		return new UserFeedListDTO.FeedDTO(feed, feedImages, likeCount, replyCount, share);
-	}
-
-	private List<UserFeedListDTO.FeedImageDTO> getFeedImageDTO(List<Media> mediaList) {
-		return mediaList.stream()
-				.map(UserFeedListDTO.FeedImageDTO::new)
-				.collect(Collectors.toList());
-	}
-
-	private User validationUserId(Long userId) {
-		return userRepository.findById(userId)
-				.orElseThrow(() -> new Exception404("에러"));
-	}
+    private User validationUserId(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new Exception404("에러"));
+    }
 }

--- a/application/src/main/resources/application-api.yml
+++ b/application/src/main/resources/application-api.yml
@@ -20,3 +20,21 @@ cloud:
       static: ap-northeast-2
     stack:
       auto: false
+
+Spring:
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: foodielog25@gmail.com
+    password: ${gmail.app.password}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000
+    auth-code-expiration-millis: 180000  # 인증 코드 만료 시간 3 * 60 * 1000 == 3분

--- a/application/src/main/resources/application-api.yml
+++ b/application/src/main/resources/application-api.yml
@@ -21,7 +21,13 @@ cloud:
     stack:
       auto: false
 
-Spring:
+spring:
+  config:
+    import: env.yml
+  redis:
+    host: ${elasticache.redis.end-point}
+    port: 6379
+
   mail:
     host: smtp.gmail.com
     port: 587

--- a/application/src/main/resources/application.yml
+++ b/application/src/main/resources/application.yml
@@ -18,10 +18,6 @@ spring:
     console:
       enabled: true
 
-  redis:
-    host: ${elasticache.redis.end-point}
-    port: 6379
-
   jpa:
     hibernate:
       ddl-auto: create

--- a/application/src/main/resources/application.yml
+++ b/application/src/main/resources/application.yml
@@ -18,9 +18,9 @@ spring:
     console:
       enabled: true
 
-  output:
-    ansi:
-      enabled: always
+  redis:
+    host: ${elasticache.redis.end-point}
+    port: 6379
 
   jpa:
     hibernate:
@@ -31,6 +31,10 @@ spring:
         show_sql: true
     defer-datasource-initialization: true
     open-in-view: true
+
+  output:
+    ansi:
+      enabled: always
 
 #  sql:
 #    init:

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation group: 'com.auth0', name: 'java-jwt', version: '4.3.0'
 }
 

--- a/core/src/main/java/com/foodielog/server/_core/customValid/valid/ValidNickName.java
+++ b/core/src/main/java/com/foodielog/server/_core/customValid/valid/ValidNickName.java
@@ -1,0 +1,19 @@
+package com.foodielog.server._core.customValid.valid;
+
+import com.foodielog.server._core.customValid.validator.NickNameValidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = NickNameValidator.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidNickName {
+    String message() default "올바른 형식의 닉네임 이어야 합니다";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/core/src/main/java/com/foodielog/server/_core/customValid/valid/ValidPassWord.java
+++ b/core/src/main/java/com/foodielog/server/_core/customValid/valid/ValidPassWord.java
@@ -1,0 +1,19 @@
+package com.foodielog.server._core.customValid.valid;
+
+import com.foodielog.server._core.customValid.validator.PassWordValidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = PassWordValidator.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidPassWord {
+    String message() default "비밀번호 형식에 맞지 않습니다";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/core/src/main/java/com/foodielog/server/_core/customValid/validator/NickNameValidator.java
+++ b/core/src/main/java/com/foodielog/server/_core/customValid/validator/NickNameValidator.java
@@ -1,0 +1,19 @@
+package com.foodielog.server._core.customValid.validator;
+
+import com.foodielog.server._core.customValid.valid.ValidNickName;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class NickNameValidator implements ConstraintValidator<ValidNickName, String> {
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        return value != null && value.length() >= 2 && isValidString(value);
+    }
+
+    private boolean isValidString(String value) {
+        // 첫 글자는 한글 또는 영문, 뒤로는 한글, 영문, 숫자, 밑줄(_)만 포함 하는 2글자 이상 되는지 검사
+        String regex = "^[가-힣a-zA-Z][가-힣a-zA-Z0-9_]*$";
+        return value.matches(regex);
+    }
+}

--- a/core/src/main/java/com/foodielog/server/_core/customValid/validator/PassWordValidator.java
+++ b/core/src/main/java/com/foodielog/server/_core/customValid/validator/PassWordValidator.java
@@ -1,0 +1,21 @@
+package com.foodielog.server._core.customValid.validator;
+
+import com.foodielog.server._core.customValid.valid.ValidPassWord;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class PassWordValidator implements ConstraintValidator<ValidPassWord, String> {
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        return value != null && isValidString(value);
+    }
+
+    private boolean isValidString(String value) {
+        // 영문 대소문자, 숫자, 특수문자는 각각 최소한 하나씩 포함, 총 8~16자
+        // 사용 가능한 특수문자 ~ ․! @ # $ % ^ & * ( ) _ - + =  [ ] [ ] | \ ; :‘ “ < > , . ? /
+        String regex = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[~․!@#\\$%^&*()_\\-+=\\[\\]{}|\\\\;:‘“<>,.?/])[a-zA-Z\\d~․!@#\\$%^&*()_\\-+=\\[\\]{}|\\\\;:‘“<>,.?/]{8,16}$";
+        return value.matches(regex);
+    }
+}
+

--- a/core/src/main/java/com/foodielog/server/_core/error/MyExceptionHandler.java
+++ b/core/src/main/java/com/foodielog/server/_core/error/MyExceptionHandler.java
@@ -9,6 +9,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import javax.validation.ConstraintViolationException;
+
 
 @Slf4j
 @RequiredArgsConstructor
@@ -38,6 +40,13 @@ public class MyExceptionHandler {
     @ExceptionHandler(Exception500.class)
     public ResponseEntity<?> serverError(Exception500 e) {
         return new ResponseEntity<>(e.body(), e.status());
+    }
+
+    // @Validated 예외 처리
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<?> inValid(ConstraintViolationException e) {
+        ApiUtils.ApiResult<?> apiResult = ApiUtils.error(e.getMessage(), HttpStatus.BAD_REQUEST);
+        return new ResponseEntity<>(apiResult, HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(Exception.class)

--- a/core/src/main/java/com/foodielog/server/_core/redis/RedisConfig.java
+++ b/core/src/main/java/com/foodielog/server/_core/redis/RedisConfig.java
@@ -1,0 +1,31 @@
+package com.foodielog.server._core.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+    @Value("${spring.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+}

--- a/core/src/main/java/com/foodielog/server/_core/redis/RedisConfig.java
+++ b/core/src/main/java/com/foodielog/server/_core/redis/RedisConfig.java
@@ -26,6 +26,7 @@ public class RedisConfig {
         RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());
         redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setEnableTransactionSupport(true);
         return redisTemplate;
     }
 }

--- a/core/src/main/java/com/foodielog/server/_core/redis/RedisService.java
+++ b/core/src/main/java/com/foodielog/server/_core/redis/RedisService.java
@@ -1,0 +1,42 @@
+package com.foodielog.server._core.redis;
+
+import com.foodielog.server._core.error.exception.Exception500;
+import com.foodielog.server._core.util.JsonConverter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class RedisService {
+    private final RedisTemplate<String, String> redisTemplate;
+    private final JsonConverter jsonConverter;
+
+    public <T> T getObjectByKey(String key, Class<T> clazz) {
+        ValueOperations<String, String> vop = redisTemplate.opsForValue();
+        String jsonString = vop.get(key);
+
+        if (jsonString == null || jsonString.isEmpty()) {
+            log.debug("redis get 오류");
+            throw new Exception500("서버 오류! #R");
+        }
+
+        T object = jsonConverter.jsonToObject(jsonString, clazz);
+        log.info("redis get 성공: " + object.toString());
+        return object;
+    }
+
+    public void setObjectByKey(String key, Object obj, Long timeOut, TimeUnit timeUnit) {
+        ValueOperations<String, String> vop = redisTemplate.opsForValue();
+        vop.set(key, jsonConverter.objectToJson(obj));
+        redisTemplate.expire(key, timeOut, timeUnit);
+        log.info("redis set 성공 key: " + key);
+    }
+}

--- a/core/src/main/java/com/foodielog/server/_core/redis/RedisService.java
+++ b/core/src/main/java/com/foodielog/server/_core/redis/RedisService.java
@@ -8,12 +8,10 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Service;
 
-import javax.transaction.Transactional;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @RequiredArgsConstructor
-@Transactional
 @Service
 public class RedisService {
     private final RedisTemplate<String, String> redisTemplate;

--- a/core/src/main/java/com/foodielog/server/_core/redis/RedisService.java
+++ b/core/src/main/java/com/foodielog/server/_core/redis/RedisService.java
@@ -1,6 +1,6 @@
 package com.foodielog.server._core.redis;
 
-import com.foodielog.server._core.error.exception.Exception500;
+import com.foodielog.server._core.error.exception.Exception400;
 import com.foodielog.server._core.util.JsonConverter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,8 +24,7 @@ public class RedisService {
         String jsonString = vop.get(key);
 
         if (jsonString == null || jsonString.isEmpty()) {
-            log.debug("redis get 오류");
-            throw new Exception500("서버 오류! #R");
+            throw new Exception400("key", "만료 됐거나 유효 하지 않은 키 입니다.");
         }
 
         T object = jsonConverter.jsonToObject(jsonString, clazz);

--- a/core/src/main/java/com/foodielog/server/_core/s3/S3Uploader.java
+++ b/core/src/main/java/com/foodielog/server/_core/s3/S3Uploader.java
@@ -2,6 +2,7 @@ package com.foodielog.server._core.s3;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.foodielog.server._core.error.exception.Exception500;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -20,7 +21,7 @@ public class S3Uploader {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
-    public String saveFile(MultipartFile multipartFile) throws IOException {
+    public String saveFile(MultipartFile multipartFile) {
         String originalFilename = multipartFile.getOriginalFilename();
 
         log.info("File upload started: " + originalFilename);
@@ -29,7 +30,11 @@ public class S3Uploader {
         metadata.setContentLength(multipartFile.getSize());
         metadata.setContentType(multipartFile.getContentType());
 
-        amazonS3.putObject(bucket, originalFilename, multipartFile.getInputStream(), metadata);
+        try {
+            amazonS3.putObject(bucket, originalFilename, multipartFile.getInputStream(), metadata);
+        } catch (IOException e) {
+            throw new Exception500("서버 오류 #F");
+        }
 
         log.info("File upload completed: " + originalFilename);
 

--- a/core/src/main/java/com/foodielog/server/_core/util/JsonConverter.java
+++ b/core/src/main/java/com/foodielog/server/_core/util/JsonConverter.java
@@ -1,0 +1,44 @@
+package com.foodielog.server._core.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.foodielog.server._core.error.exception.Exception500;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+
+@Slf4j
+@Component
+public class JsonConverter {
+    private ObjectMapper objectMapper;
+
+    @PostConstruct
+    public void init() {
+        objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+        objectMapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
+    }
+
+    public String objectToJson(Object obj) {
+        String jsonStr = "";
+        try {
+            jsonStr = objectMapper.writeValueAsString(obj);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new Exception500("Json 파싱 오류(1)");
+        }
+        return jsonStr;
+    }
+
+    public <T> T jsonToObject(String json, Class<T> clazz) {
+        T obj = null;
+        try {
+            obj = objectMapper.readValue(json, clazz);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new Exception500("Json 파싱 오류(2)");
+        }
+        return obj;
+    }
+}

--- a/core/src/main/java/com/foodielog/server/user/entity/User.java
+++ b/core/src/main/java/com/foodielog/server/user/entity/User.java
@@ -1,29 +1,19 @@
 package com.foodielog.server.user.entity;
 
-import java.sql.Timestamp;
-
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Table;
-
+import com.foodielog.server.user.type.Flag;
+import com.foodielog.server.user.type.ProviderType;
+import com.foodielog.server.user.type.Role;
+import com.foodielog.server.user.type.UserStatus;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.UpdateTimestamp;
 
-import com.foodielog.server.user.type.Flag;
-import com.foodielog.server.user.type.Role;
-import com.foodielog.server.user.type.ProviderType;
-import com.foodielog.server.user.type.UserStatus;
-
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import javax.persistence.*;
+import java.sql.Timestamp;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -31,61 +21,72 @@ import lombok.NoArgsConstructor;
 @Table(name = "user_tb")
 @Entity
 public class User {
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-	@Column(nullable = false, length = 255, unique = true)
-	private String email;
+    @Column(nullable = false, length = 255, unique = true)
+    private String email;
 
-	@Column(nullable = false, length = 60)
-	private String password;
+    @Column(nullable = false, length = 60)
+    private String password;
 
-	@Column(nullable = false, length = 5)
-	@Enumerated(EnumType.STRING)
-	private ProviderType provider;
+    @Column(nullable = false, length = 5)
+    @Enumerated(EnumType.STRING)
+    @ColumnDefault("'ME'")
+    private ProviderType provider;
 
-	@Column(nullable = false, length = 10)
-	@Enumerated(EnumType.STRING)
-	@ColumnDefault("'USER'")
-	private Role role;
+    @Column(nullable = false, length = 10)
+    @Enumerated(EnumType.STRING)
+    @ColumnDefault("'USER'")
+    private Role role;
 
-	@Column(nullable = false, length = 50, unique = true)
-	private String nickName;
+    @Column(nullable = false, length = 50, unique = true)
+    private String nickName;
 
-	@Column(length = 255)
-	private String profileImageUrl;
+    @Column(length = 255)
+    private String profileImageUrl;
 
-	@Column(length = 150)
-	private String aboutMe;
+    @Column(length = 150)
+    private String aboutMe;
 
-	@Column(nullable = false, length = 1)
-	@Enumerated(EnumType.STRING)
-	@ColumnDefault("'Y'")
-	private Flag notificationFlag;
+    @Column(nullable = false, length = 1)
+    @Enumerated(EnumType.STRING)
+    @ColumnDefault("'Y'")
+    private Flag notificationFlag;
 
-	@Column(nullable = false, length = 1)
-	@Enumerated(EnumType.STRING)
-	@ColumnDefault("'N'")
-	private Flag badgeFlag;
+    @Column(nullable = false, length = 1)
+    @Enumerated(EnumType.STRING)
+    @ColumnDefault("'N'")
+    private Flag badgeFlag;
 
-	@Column(nullable = false, length = 10)
-	@Enumerated(EnumType.STRING)
-	@ColumnDefault("'NORMAL'")
-	private UserStatus status;
+    @Column(nullable = false, length = 10)
+    @Enumerated(EnumType.STRING)
+    @ColumnDefault("'NORMAL'")
+    private UserStatus status;
 
-	@CreationTimestamp
-	private Timestamp createdAt;
+    @CreationTimestamp
+    private Timestamp createdAt;
 
-	@UpdateTimestamp
-	private Timestamp updatedAt;
+    @UpdateTimestamp
+    private Timestamp updatedAt;
 
-	public static User createSocialUser(Long id, String email, String password, ProviderType provider) {
-		User user = new User();
-		user.email = email;
-		user.password = password;
-		user.provider = provider;
-		user.nickName = provider+id.toString();
-		return user;
-	}
+    public static User createUser(String email, String password, String nickName, String profileImageUrl, String aboutMe) {
+        User user = new User();
+        user.email = email;
+        user.password = password;
+        user.nickName = nickName;
+        user.profileImageUrl = profileImageUrl;
+        user.aboutMe = aboutMe;
+        return user;
+    }
+
+    public static User createSocialUser(Long providerId, String email, String password, ProviderType provider) {
+        User user = new User();
+        user.email = email;
+        user.password = password;
+        user.provider = provider;
+        user.nickName = provider + providerId.toString();
+        return user;
+    }
 }

--- a/core/src/main/java/com/foodielog/server/user/repository/UserRepository.java
+++ b/core/src/main/java/com/foodielog/server/user/repository/UserRepository.java
@@ -1,13 +1,14 @@
 package com.foodielog.server.user.repository;
 
-import java.util.Optional;
-
+import com.foodielog.server.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.foodielog.server.user.entity.User;
+import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-	Optional<User> findByEmail(String email);
+    Optional<User> findByEmail(String email);
 
-	Boolean existsByEmail(String email);
+    Boolean existsByEmail(String email);
+
+    Boolean existsByNickName(String nickName);
 }

--- a/management/src/main/resources/application-api.yml
+++ b/management/src/main/resources/application-api.yml
@@ -20,3 +20,27 @@ cloud:
       static: ap-northeast-2
     stack:
       auto: false
+
+spring:
+  config:
+    import: env.yml
+  redis:
+    host: ${elasticache.redis.end-point}
+    port: 6379
+
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: foodielog25@gmail.com
+    password: ${gmail.app.password}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000
+    auth-code-expiration-millis: 180000  # 인증 코드 만료 시간 3 * 60 * 1000 == 3분

--- a/management/src/main/resources/application.yml
+++ b/management/src/main/resources/application.yml
@@ -18,10 +18,6 @@ spring:
     console:
       enabled: true
 
-  output:
-    ansi:
-      enabled: always
-
   jpa:
     hibernate:
       ddl-auto: create
@@ -31,6 +27,10 @@ spring:
         show_sql: true
     defer-datasource-initialization: true
     open-in-view: true
+
+  output:
+    ansi:
+      enabled: always
 
 #  sql:
 #    init:


### PR DESCRIPTION
## 요약
자체 회원가입 관련 api 구현

## 작업 내용

- [X]  이메일 중복체크
- [X]  이메일 인증
- [X]  프로필 설정(S3)

## 참고 사항
### 이메일 인증 
1. 코드 요청 api 는 가입용, 비밀번호 설정용 분리
- 가입시: 이메일 체크(중복되면 안됨)
- 비밀번호 설정 시: 이메일 체크(로그인 유저의 이메일)
2.  코드 검증 api는 하나로 통일 


### 프로필 설정
1. api 가입 시 초기 설정용 이후 마이페이지에서 설정용 분리
- 초기 설정 시: 이미지 필수, 닉네임 필수, 자기소개 선택
- 마이페이지에서 설정 시: 로그인 유저 체크, 이미지 선택, 닉네임 필수, 자기소개 선택
 
## 관련 이슈
Close #24
