### PR TITLE
[Refactor] #39 S3 uploader 리팩토링

### DIFF
--- a/application/src/main/java/com/foodielog/application/feed/controller/FeedController.java
+++ b/application/src/main/java/com/foodielog/application/feed/controller/FeedController.java
@@ -4,7 +4,6 @@ import com.foodielog.application.feed.dto.FeedRequest;
 import com.foodielog.application.feed.service.FeedService;
 import com.foodielog.server._core.error.ErrorMessage;
 import com.foodielog.server._core.error.exception.Exception400;
-import com.foodielog.server._core.error.exception.Exception500;
 import com.foodielog.server._core.kakaoApi.KakaoApiResponse;
 import com.foodielog.server._core.kakaoApi.KakaoApiService;
 import com.foodielog.server._core.security.auth.PrincipalDetails;
@@ -20,7 +19,6 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
-import java.io.IOException;
 import java.util.List;
 
 @Slf4j
@@ -51,14 +49,10 @@ public class FeedController {
         if (files == null || files.isEmpty()) {
             throw new Exception400("files", ErrorMessage.NO_SELECTED_IMAGE);
         }
-        // TODO : 이미지 url이 80 이상인 경우 s3에는 업로드 되고, db에는 url 길이 제한으로 저장에 실패하는 경우 고려.
-        try {
-            User user = principalDetails.getUser();
-            feedService.save(saveDTO, files, user);
 
-            return new ResponseEntity<>(ApiUtils.success(null, HttpStatus.OK), HttpStatus.OK);
-        } catch (IOException e) {
-            throw new Exception500(ErrorMessage.FAIL_UPLOAD);
-        }
+        User user = principalDetails.getUser();
+        feedService.save(saveDTO, files, user);
+
+        return new ResponseEntity<>(ApiUtils.success(null, HttpStatus.OK), HttpStatus.OK);
     }
 }

--- a/application/src/main/resources/application-api.yml
+++ b/application/src/main/resources/application-api.yml
@@ -15,7 +15,7 @@ kakao:
 cloud:
   aws:
     s3:
-      bucket: inyoungbucket
+      bucket: foodielog-bucket
     region:
       static: ap-northeast-2
     stack:

--- a/application/src/main/resources/application.yml
+++ b/application/src/main/resources/application.yml
@@ -32,6 +32,10 @@ spring:
     ansi:
       enabled: always
 
+  servlet:
+    multipart:
+      max-file-size: 3MB
+
 #  sql:
 #    init:
 #      mode: always

--- a/application/src/test/resources/application-api.yml
+++ b/application/src/test/resources/application-api.yml
@@ -15,7 +15,7 @@ kakao:
 cloud:
   aws:
     s3:
-      bucket: inyoungbucket
+      bucket: foodielog-bucket
     region:
       static: ap-northeast-2
     stack:

--- a/application/src/test/resources/application.yml
+++ b/application/src/test/resources/application.yml
@@ -32,6 +32,10 @@ spring:
     ansi:
       enabled: always
 
+  servlet:
+    multipart:
+      max-file-size: 3MB
+
 #  sql:
 #    init:
 #      mode: always

--- a/core/src/main/java/com/foodielog/server/_core/error/ErrorMessage.java
+++ b/core/src/main/java/com/foodielog/server/_core/error/ErrorMessage.java
@@ -6,4 +6,9 @@ public class ErrorMessage {
 
     public static final String FAIL_UPLOAD = "사진 전송에 실패하였습니다.";
     public static final String NO_SELECTED_IMAGE = "선택된 사진이 없습니다.";
+    public static final String EXCEED_IMAGE_SIZE = "사진의 용량이 커서 업로드 할 수 없습니다.";
+    public static final String NOT_IMAGE_EXTENSION = "사진만 업로드 가능합니다.";
+    public static final String DUPLICATE_IMAGE = "동일한 사진은 업로드 할 수 없습니다.";
+    public static final String FAIL_DELETE = "사진 삭제에 실패하였습니다.";
+    public static final String NO_IMAGE_EXIST = "해당 사진이 존재하지 않습니다.";
 }

--- a/core/src/main/java/com/foodielog/server/_core/s3/S3Uploader.java
+++ b/core/src/main/java/com/foodielog/server/_core/s3/S3Uploader.java
@@ -1,7 +1,11 @@
 package com.foodielog.server._core.s3;
 
+import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.foodielog.server._core.error.ErrorMessage;
+import com.foodielog.server._core.error.exception.Exception400;
 import com.foodielog.server._core.error.exception.Exception500;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -10,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.*;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -17,27 +22,126 @@ import java.io.IOException;
 public class S3Uploader {
 
     private final AmazonS3 amazonS3;
+    private Set<String> uploadedFileNames = new HashSet<>();
+    private Set<Long> uploadedFileSizes = new HashSet<>();
 
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
-    public String saveFile(MultipartFile multipartFile) {
-        String originalFilename = multipartFile.getOriginalFilename();
+    @Value("${spring.servlet.multipart.max-file-size}")
+    private String maxSizeString;
 
-        log.info("File upload started: " + originalFilename);
+    public List<String> saveFiles(List<MultipartFile> multipartFiles) {
+        List<String> uploadedUrls = new ArrayList<>();
+        long maxSize = parseMaxSize(maxSizeString);
+
+        for (MultipartFile multipartFile : multipartFiles) {
+            if (multipartFile.getSize() > maxSize) {
+                throw new Exception400("file : ", ErrorMessage.EXCEED_IMAGE_SIZE);
+            }
+
+            String uploadedUrl = saveFile(multipartFile);
+            uploadedUrls.add(uploadedUrl);
+        }
+
+        clear();
+        return uploadedUrls;
+    }
+
+    public void deleteFile(String fileUrl) {
+        String[] urlParts = fileUrl.split("/");
+        String fileBucket = urlParts[2].replace(".s3.amazonaws.com", "");
+
+        if (!fileBucket.equals(bucket)) {
+            throw new Exception400("fileUrl", ErrorMessage.NO_IMAGE_EXIST);
+        }
+
+        String objectKey = String.join("/", Arrays.copyOfRange(urlParts, 3, urlParts.length));
+
+        if (!amazonS3.doesObjectExist(bucket, objectKey)) {
+            throw new Exception400("fileUrl", ErrorMessage.NO_IMAGE_EXIST);
+        }
+
+        try {
+            amazonS3.deleteObject(bucket, objectKey);
+        } catch (AmazonS3Exception e) {
+            log.error("File delete fail : " + e.getMessage());
+            throw new Exception500(ErrorMessage.FAIL_DELETE);
+        } catch (SdkClientException e) {
+            log.error("AWS SDK client error : " + e.getMessage());
+            throw new Exception500(ErrorMessage.FAIL_DELETE);
+        }
+    }
+
+    private long parseMaxSize(String maxSizeString) {
+        String numericValue = maxSizeString.replaceAll("[^0-9]", "");
+        return Long.parseLong(numericValue) * 1024 * 1024;
+    }
+
+    private String saveFile(MultipartFile multipartFile) {
+        if (isDuplicate(multipartFile)) {
+            throw new Exception400("file", ErrorMessage.DUPLICATE_IMAGE);
+        }
+
+        String randomFilename = generateRandomFilename(multipartFile);
+
+        log.info("File upload started: " + randomFilename);
 
         ObjectMetadata metadata = new ObjectMetadata();
         metadata.setContentLength(multipartFile.getSize());
         metadata.setContentType(multipartFile.getContentType());
 
         try {
-            amazonS3.putObject(bucket, originalFilename, multipartFile.getInputStream(), metadata);
+            amazonS3.putObject(bucket, randomFilename, multipartFile.getInputStream(), metadata);
+        } catch (AmazonS3Exception e) {
+            log.error("Amazon S3 error while uploading file: " + e.getMessage());
+            throw new Exception500(ErrorMessage.FAIL_UPLOAD);
+        } catch (SdkClientException e) {
+            log.error("AWS SDK client error while uploading file: " + e.getMessage());
+            throw new Exception500(ErrorMessage.FAIL_UPLOAD);
         } catch (IOException e) {
-            throw new Exception500("서버 오류 #F");
+            log.error("IO error while uploading file: " + e.getMessage());
+            throw new Exception500(ErrorMessage.FAIL_UPLOAD);
         }
 
-        log.info("File upload completed: " + originalFilename);
+        log.info("File upload completed: " + randomFilename);
 
-        return amazonS3.getUrl(bucket, originalFilename).toString();
+        return amazonS3.getUrl(bucket, randomFilename).toString();
+    }
+
+    private boolean isDuplicate(MultipartFile multipartFile) {
+        String fileName = multipartFile.getOriginalFilename();
+        Long fileSize = multipartFile.getSize();
+
+        if (uploadedFileNames.contains(fileName) && uploadedFileSizes.contains(fileSize)) {
+            return true;
+        }
+
+        uploadedFileNames.add(fileName);
+        uploadedFileSizes.add(fileSize);
+
+        return false;
+    }
+
+    private void clear() {
+        uploadedFileNames.clear();
+        uploadedFileSizes.clear();
+    }
+
+    private String generateRandomFilename(MultipartFile multipartFile) {
+        String originalFilename = multipartFile.getOriginalFilename();
+        String fileExtension = validateFileExtension(originalFilename);
+        String randomFilename = UUID.randomUUID() + "." + fileExtension;
+        return randomFilename;
+    }
+
+    private String validateFileExtension(String originalFilename) {
+        String fileExtension = originalFilename.substring(originalFilename.lastIndexOf(".") + 1).toLowerCase();
+        List<String> allowedExtensions = Arrays.asList("jpg", "png", "gif", "jpeg");
+
+        if (!allowedExtensions.contains(fileExtension)) {
+            throw new Exception400("file", ErrorMessage.NOT_IMAGE_EXTENSION);
+        }
+        return fileExtension;
     }
 }

--- a/management/src/main/resources/application-api.yml
+++ b/management/src/main/resources/application-api.yml
@@ -15,7 +15,7 @@ kakao:
 cloud:
   aws:
     s3:
-      bucket: inyoungbucket
+      bucket: foodielog-bucket
     region:
       static: ap-northeast-2
     stack:

--- a/management/src/main/resources/application.yml
+++ b/management/src/main/resources/application.yml
@@ -32,6 +32,10 @@ spring:
     ansi:
       enabled: always
 
+  servlet:
+    multipart:
+      max-file-size: 3MB
+
 #  sql:
 #    init:
 #      mode: always

--- a/management/src/test/resources/application-api.yml
+++ b/management/src/test/resources/application-api.yml
@@ -15,7 +15,7 @@ kakao:
 cloud:
   aws:
     s3:
-      bucket: inyoungbucket
+      bucket: foodielog-bucket
     region:
       static: ap-northeast-2
     stack:

--- a/management/src/test/resources/application.yml
+++ b/management/src/test/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: 8080
+  port: 8081
   servlet:
     encoding:
       charset: UTF-8

--- a/management/src/test/resources/application.yml
+++ b/management/src/test/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: 8081
+  port: 8080
   servlet:
     encoding:
       charset: UTF-8
@@ -31,6 +31,10 @@ spring:
   output:
     ansi:
       enabled: always
+
+  servlet:
+    multipart:
+      max-file-size: 3MB
 
 #  sql:
 #    init:


### PR DESCRIPTION
## 요약
s3 uploader 리팩토링 완료

## 작업 내용
- [x] 파일 크기, 확장자 제한 추가
- [x] 동일 파일 다중 업로드 제한 추가
- [x] throw > try-cathc 로 수정

## 참고 사항
`백엔드`에서는 `피드 업로드 버튼`으로 이미지를 한번에 받기 때문에, 이미지 선택 시 실시간 체크는 `프론트`와 상의 해야함

## 관련 이슈
Close #39 
