### PR TITLE
[Feat] #28 마이페이지 맛집 리스트, 맛집 상세페이지 구현

### DIFF
--- a/application/src/main/java/com/foodielog/application/user/controller/UserController.java
+++ b/application/src/main/java/com/foodielog/application/user/controller/UserController.java
@@ -21,38 +21,48 @@ public class UserController {
     private final UserService userService;
 
     @GetMapping("/{userId}/profile")
-    public ResponseEntity<?> getProfile(@PathVariable Long userId) {
+    public ResponseEntity<?> getProfile(
+            @PathVariable Long userId
+    ) {
         UserProfileDTO.Response response = userService.getProfile(userId);
         return new ResponseEntity<>(ApiUtils.success(response, HttpStatus.OK), HttpStatus.OK);
     }
 
     @GetMapping("/{userId}/feed/thumbnail")
-    public ResponseEntity<?> getThumbnail(@PathVariable Long userId,
-                                          @RequestParam(name = "feed") Long feedId,
-                                          @PageableDefault(size = 15) Pageable pageable) {
+    public ResponseEntity<?> getThumbnail(
+            @PathVariable Long userId,
+            @RequestParam(name = "feed") Long feedId,
+            @PageableDefault(size = 15) Pageable pageable
+    ) {
         UserThumbnailDTO.Response response = userService.getThumbnail(userId, feedId, pageable);
         return new ResponseEntity<>(ApiUtils.success(response, HttpStatus.OK), HttpStatus.OK);
     }
 
     @GetMapping("/{userId}/feed/list")
-    public ResponseEntity<?> getFeeds(@PathVariable Long userId,
-                                      @RequestParam(name = "feed") Long feedId,
-                                      @PageableDefault(size = 15) Pageable pageable) {
+    public ResponseEntity<?> getFeeds(
+            @PathVariable Long userId,
+            @RequestParam(name = "feed") Long feedId,
+            @PageableDefault(size = 15) Pageable pageable
+    ) {
         UserFeedListDTO.Response response = userService.getFeeds(userId, feedId, pageable);
         return new ResponseEntity<>(ApiUtils.success(response, HttpStatus.OK), HttpStatus.OK);
     }
 
     @GetMapping("/{userId}/map")
-    public ResponseEntity<?> getRestaurantListByMap(@AuthenticationPrincipal PrincipalDetails principalDetails,
-                                                    @PathVariable Long userId) {
+    public ResponseEntity<?> getRestaurantListByMap(
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @PathVariable Long userId
+    ) {
         User user = principalDetails.getUser();
         UserRestaurantListDTO.Response response = userService.getRestaurantList(userId, user);
         return new ResponseEntity<>(ApiUtils.success(response, HttpStatus.OK), HttpStatus.OK);
     }
 
     @GetMapping("/restaurant/{restaurantId}")
-    public ResponseEntity<?> getRestaurantDetail(@AuthenticationPrincipal PrincipalDetails principalDetails,
-                                                 @PathVariable Long restaurantId) {
+    public ResponseEntity<?> getRestaurantDetail(
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @PathVariable Long restaurantId
+    ) {
         User user = principalDetails.getUser();
         RestaurantFeedListDTO.Response response = userService.getRestaurantDetail(user, restaurantId);
         return new ResponseEntity<>(ApiUtils.success(response, HttpStatus.OK), HttpStatus.OK);

--- a/application/src/main/java/com/foodielog/application/user/controller/UserController.java
+++ b/application/src/main/java/com/foodielog/application/user/controller/UserController.java
@@ -1,15 +1,16 @@
 package com.foodielog.application.user.controller;
 
-import com.foodielog.application.user.dto.UserFeedListDTO;
-import com.foodielog.application.user.dto.UserProfileDTO;
-import com.foodielog.application.user.dto.UserThumbnailDTO;
+import com.foodielog.application.user.dto.*;
 import com.foodielog.application.user.service.UserService;
+import com.foodielog.server._core.security.auth.PrincipalDetails;
 import com.foodielog.server._core.util.ApiUtils;
+import com.foodielog.server.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
@@ -38,6 +39,22 @@ public class UserController {
                                       @RequestParam(name = "feed") Long feedId,
                                       @PageableDefault(size = 15) Pageable pageable) {
         UserFeedListDTO.Response response = userService.getFeeds(userId, feedId, pageable);
+        return new ResponseEntity<>(ApiUtils.success(response, HttpStatus.OK), HttpStatus.OK);
+    }
+
+    @GetMapping("/{userId}/map")
+    public ResponseEntity<?> getRestaurantListByMap(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                    @PathVariable Long userId) {
+        User user = principalDetails.getUser();
+        UserRestaurantListDTO.Response response = userService.getRestaurantList(userId, user);
+        return new ResponseEntity<>(ApiUtils.success(response, HttpStatus.OK), HttpStatus.OK);
+    }
+
+    @GetMapping("/restaurant/{restaurantId}")
+    public ResponseEntity<?> getRestaurantDetail(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                 @PathVariable Long restaurantId) {
+        User user = principalDetails.getUser();
+        RestaurantFeedListDTO.Response response = userService.getRestaurantDetail(user, restaurantId);
         return new ResponseEntity<>(ApiUtils.success(response, HttpStatus.OK), HttpStatus.OK);
     }
 }

--- a/application/src/main/java/com/foodielog/application/user/dto/RestaurantFeedListDTO.java
+++ b/application/src/main/java/com/foodielog/application/user/dto/RestaurantFeedListDTO.java
@@ -13,11 +13,11 @@ public class RestaurantFeedListDTO {
 
     @Getter
     public static class Response {
-        private final RestaurantInfoDTO restaurantInfoDTO;
+        private final RestaurantInfoDTO restaurantInfo;
         private final List<RestaurantFeedsDTO> content;
 
-        public Response(RestaurantInfoDTO restaurantInfoDTO, List<RestaurantFeedsDTO> content) {
-            this.restaurantInfoDTO = restaurantInfoDTO;
+        public Response(RestaurantInfoDTO restaurantInfo, List<RestaurantFeedsDTO> content) {
+            this.restaurantInfo = restaurantInfo;
             this.content = content;
         }
     }

--- a/application/src/main/java/com/foodielog/application/user/dto/RestaurantFeedListDTO.java
+++ b/application/src/main/java/com/foodielog/application/user/dto/RestaurantFeedListDTO.java
@@ -1,0 +1,136 @@
+package com.foodielog.application.user.dto;
+
+import com.foodielog.server.feed.entity.Feed;
+import com.foodielog.server.feed.entity.Media;
+import com.foodielog.server.restaurant.entity.Restaurant;
+import lombok.Getter;
+import org.springframework.lang.Nullable;
+
+import java.sql.Timestamp;
+import java.util.List;
+
+public class RestaurantFeedListDTO {
+
+    @Getter
+    public static class Response {
+        private final RestaurantInfoDTO restaurantInfoDTO;
+        private final List<RestaurantFeedsDTO> content;
+
+        public Response(RestaurantInfoDTO restaurantInfoDTO, List<RestaurantFeedsDTO> content) {
+            this.restaurantInfoDTO = restaurantInfoDTO;
+            this.content = content;
+        }
+    }
+
+    @Getter
+    public static class RestaurantInfoDTO {
+        private final RestaurantDTO restaurantDTO;
+        private final IsLikedDTO isLikedDTO;
+
+        public RestaurantInfoDTO(RestaurantDTO restaurantDTO, IsLikedDTO isLikedDTO) {
+            this.restaurantDTO = restaurantDTO;
+            this.isLikedDTO = isLikedDTO;
+        }
+    }
+
+    @Getter
+    public static class RestaurantFeedsDTO {
+        private final FeedDTO feed;
+        private final FeedRestaurantDTO restaurant;
+        private final boolean isFollowed;
+        private final boolean isLiked;
+
+        public RestaurantFeedsDTO(FeedDTO feed, FeedRestaurantDTO restaurant, boolean isFollowed, boolean isLiked) {
+            this.feed = feed;
+            this.restaurant = restaurant;
+            this.isFollowed = isFollowed;
+            this.isLiked = isLiked;
+        }
+    }
+
+    @Getter
+    public static class RestaurantDTO {
+        private final String name;
+        private final String category;
+        private final String link;
+        private final String roadAddress;
+        private final String mapX;
+        private final String mapY;
+
+        public RestaurantDTO(Restaurant restaurant) {
+            this.name = restaurant.getName();
+            this.category = restaurant.getCategory();
+            this.link = restaurant.getLink();
+            this.roadAddress = restaurant.getRoadAddress();
+            this.mapX = restaurant.getMapX();
+            this.mapY = restaurant.getMapY();
+        }
+    }
+
+    @Getter
+    public static class IsLikedDTO {
+
+        @Nullable
+        private final Long id;
+
+        private final boolean isLiked;
+
+        public IsLikedDTO(Long id, boolean isLiked) {
+            this.id = id;
+            this.isLiked = isLiked;
+        }
+    }
+
+    @Getter
+    public static class FeedDTO {
+        private final Long feedId;
+        private final String nickName;
+        private final String profileImageUrl;
+        private final Timestamp createdAt;
+        private final Timestamp updatedAt;
+        private final List<FeedImageDTO> feedImages;
+        private final String content;
+        private final Long likeCount;
+        private final Long replyCount;
+        private final String share;
+
+        public FeedDTO(Feed feed, List<FeedImageDTO> feedImages, Long likeCount, Long replyCount, String share) {
+            this.feedId = feed.getId();
+            this.nickName = feed.getUser().getNickName();
+            this.profileImageUrl = feed.getUser().getProfileImageUrl();
+            this.createdAt = feed.getCreatedAt();
+            this.updatedAt = feed.getUpdatedAt();
+            this.feedImages = feedImages;
+            this.content = feed.getContent();
+            this.likeCount = likeCount;
+            this.replyCount = replyCount;
+            this.share = share;
+        }
+    }
+
+    @Getter
+    public static class FeedImageDTO {
+        private final String imageUrl;
+
+        public FeedImageDTO(Media media) {
+            this.imageUrl = media.getImageUrl();
+        }
+    }
+
+    @Getter
+    public static class FeedRestaurantDTO {
+        private final Long id;
+        private final String name;
+        private final String category;
+        private final String link;
+        private final String roadAddress;
+
+        public FeedRestaurantDTO(Restaurant restaurant) {
+            this.id = restaurant.getId();
+            this.name = restaurant.getName();
+            this.category = restaurant.getCategory();
+            this.link = restaurant.getLink();
+            this.roadAddress = restaurant.getRoadAddress();
+        }
+    }
+}

--- a/application/src/main/java/com/foodielog/application/user/dto/UserFeedListDTO.java
+++ b/application/src/main/java/com/foodielog/application/user/dto/UserFeedListDTO.java
@@ -75,14 +75,14 @@ public class UserFeedListDTO {
         private final String name;
         private final String category;
         private final String link;
-        private final String readAddress;
+        private final String roadAddress;
 
         public UserRestaurantDTO(Restaurant restaurant) {
             this.id = restaurant.getId();
             this.name = restaurant.getName();
             this.category = restaurant.getCategory();
             this.link = restaurant.getLink();
-            this.readAddress = restaurant.getRoadAddress();
+            this.roadAddress = restaurant.getRoadAddress();
         }
     }
 }

--- a/application/src/main/java/com/foodielog/application/user/dto/UserRestaurantListDTO.java
+++ b/application/src/main/java/com/foodielog/application/user/dto/UserRestaurantListDTO.java
@@ -1,0 +1,65 @@
+package com.foodielog.application.user.dto;
+
+import com.foodielog.server.restaurant.entity.Restaurant;
+import lombok.Getter;
+import org.springframework.lang.Nullable;
+
+import java.util.List;
+
+public class UserRestaurantListDTO {
+
+    @Getter
+    public static class Response {
+        private final List<RestaurantListDTO> content;
+
+        public Response(List<RestaurantListDTO> content) {
+            this.content = content;
+        }
+
+        @Getter
+        public static class RestaurantListDTO {
+            private final RestaurantDTO restaurant;
+            private final IsLikedDTO isLikedDTO;
+
+            public RestaurantListDTO(RestaurantDTO restaurant, IsLikedDTO isLikedDTO) {
+                this.restaurant = restaurant;
+                this.isLikedDTO = isLikedDTO;
+            }
+        }
+
+        @Getter
+        public static class RestaurantDTO {
+            private final Long id;
+            private final String name;
+            private final String category;
+            private final String link;
+            private final String roadAddress;
+            private final String mapX;
+            private final String mapY;
+
+            public RestaurantDTO(Restaurant restaurant) {
+                this.id = restaurant.getId();
+                this.name = restaurant.getName();
+                this.category = restaurant.getCategory();
+                this.link = restaurant.getLink();
+                this.roadAddress = restaurant.getRoadAddress();
+                this.mapX = restaurant.getMapX();
+                this.mapY = restaurant.getMapY();
+            }
+        }
+
+        @Getter
+        public static class IsLikedDTO {
+
+            @Nullable
+            private final Long id;
+
+            private final boolean isLiked;
+
+            public IsLikedDTO(Long id, boolean isLiked) {
+                this.id = id;
+                this.isLiked = isLiked;
+            }
+        }
+    }
+}

--- a/application/src/main/java/com/foodielog/application/user/service/UserService.java
+++ b/application/src/main/java/com/foodielog/application/user/service/UserService.java
@@ -1,8 +1,6 @@
 package com.foodielog.application.user.service;
 
-import com.foodielog.application.user.dto.UserFeedListDTO;
-import com.foodielog.application.user.dto.UserProfileDTO;
-import com.foodielog.application.user.dto.UserThumbnailDTO;
+import com.foodielog.application.user.dto.*;
 import com.foodielog.server._core.error.exception.Exception404;
 import com.foodielog.server.feed.entity.Feed;
 import com.foodielog.server.feed.entity.Media;
@@ -11,7 +9,9 @@ import com.foodielog.server.feed.repository.FeedRepository;
 import com.foodielog.server.feed.repository.MediaRepository;
 import com.foodielog.server.reply.repository.ReplyRepository;
 import com.foodielog.server.restaurant.entity.Restaurant;
+import com.foodielog.server.restaurant.entity.RestaurantLike;
 import com.foodielog.server.restaurant.repository.RestaurantLikeRepository;
+import com.foodielog.server.restaurant.repository.RestaurantRepository;
 import com.foodielog.server.user.entity.User;
 import com.foodielog.server.user.repository.FollowRepository;
 import com.foodielog.server.user.repository.UserRepository;
@@ -36,6 +36,7 @@ public class UserService {
     private final FeedLikeRepository feedLikeRepository;
     private final RestaurantLikeRepository restaurantLikeRepository;
     private final ReplyRepository replyRepository;
+    private final RestaurantRepository restaurantRepository;
 
     @Transactional(readOnly = true)
     public UserProfileDTO.Response getProfile(Long userId) {
@@ -85,6 +86,42 @@ public class UserService {
         return new UserFeedListDTO.Response(userFeedsDTOList);
     }
 
+    @Transactional(readOnly = true)
+    public UserRestaurantListDTO.Response getRestaurantList(Long userId, User user) {
+        User feedOwner = validationUserId(userId);
+        List<Feed> feeds = feedRepository.findByUserId(feedOwner.getId());
+
+        List<UserRestaurantListDTO.Response.RestaurantListDTO> restaurantListDTOList = new ArrayList<>();
+
+        for (Feed feed : feeds) {
+            Restaurant restaurant = feed.getRestaurant();
+            UserRestaurantListDTO.Response.RestaurantDTO restaurantDTO =
+                    new UserRestaurantListDTO.Response.RestaurantDTO(restaurant);
+
+            RestaurantLike restaurantLike =
+                    restaurantLikeRepository.findByUserIdAndRestaurantId(user.getId(), restaurant.getId());
+
+            UserRestaurantListDTO.Response.IsLikedDTO isLikedDTO = (restaurantLike == null)
+                    ? new UserRestaurantListDTO.Response.IsLikedDTO(null, false)
+                    : new UserRestaurantListDTO.Response.IsLikedDTO(restaurantLike.getId(), true);
+
+            restaurantListDTOList.add(new UserRestaurantListDTO.Response.RestaurantListDTO(restaurantDTO, isLikedDTO));
+        }
+
+        return new UserRestaurantListDTO.Response(restaurantListDTOList);
+    }
+
+    @Transactional(readOnly = true)
+    public RestaurantFeedListDTO.Response getRestaurantDetail(User user, Long restaurantId) {
+        Restaurant restaurant = restaurantRepository.findById(restaurantId)
+                .orElseThrow(() -> new Exception404("에러"));
+
+        RestaurantFeedListDTO.RestaurantInfoDTO restaurantInfoDTO = createRestaurantInfoDTO(restaurant, user);
+        List<RestaurantFeedListDTO.RestaurantFeedsDTO> restaurantFeedsDTOList = createRestaurantFeedsDTO(restaurant, user);
+
+        return new RestaurantFeedListDTO.Response(restaurantInfoDTO, restaurantFeedsDTOList);
+    }
+
     private UserFeedListDTO.UserRestaurantDTO getUserRestaurantDTO(Feed feed) {
         Restaurant restaurant = feed.getRestaurant();
         return new UserFeedListDTO.UserRestaurantDTO(restaurant);
@@ -107,5 +144,53 @@ public class UserService {
     private User validationUserId(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new Exception404("에러"));
+    }
+
+    private RestaurantFeedListDTO.RestaurantInfoDTO createRestaurantInfoDTO(Restaurant restaurant, User user) {
+        RestaurantFeedListDTO.RestaurantDTO restaurantDTO = new RestaurantFeedListDTO.RestaurantDTO(restaurant);
+
+        RestaurantLike restaurantLike =
+                restaurantLikeRepository.findByUserIdAndRestaurantId(user.getId(), restaurant.getId());
+
+        RestaurantFeedListDTO.IsLikedDTO isLikedDTO = (restaurantLike == null)
+                ? new RestaurantFeedListDTO.IsLikedDTO(null, false)
+                : new RestaurantFeedListDTO.IsLikedDTO(restaurantLike.getId(), true);
+
+        return new RestaurantFeedListDTO.RestaurantInfoDTO(restaurantDTO, isLikedDTO);
+    }
+
+    private List<RestaurantFeedListDTO.RestaurantFeedsDTO> createRestaurantFeedsDTO(Restaurant restaurant, User user) {
+        RestaurantFeedListDTO.FeedRestaurantDTO feedRestaurantDTO =
+                new RestaurantFeedListDTO.FeedRestaurantDTO(restaurant);
+
+        List<RestaurantFeedListDTO.RestaurantFeedsDTO> restaurantFeedsDTOList = new ArrayList<>();
+        List<Feed> feeds = feedRepository.findAllByRestaurantId(restaurant.getId());
+
+        for (Feed feed : feeds) {
+            List<Media> mediaList = mediaRepository.findByFeed(feed);
+            List<RestaurantFeedListDTO.FeedImageDTO> feedImageDTOS = mediaList.stream()
+                    .map(RestaurantFeedListDTO.FeedImageDTO::new)
+                    .collect(Collectors.toList());
+
+            Long likeCount = feedLikeRepository.countByFeed(feed);
+            Long replyCount = replyRepository.countByFeed(feed);
+
+            boolean isFollowed = followRepository.findByFollowingIdAndFollowedId(user, feed.getUser())
+                    .isPresent();
+            boolean isLiked = feedLikeRepository.findByUserId(user.getId())
+                    .isPresent();
+
+            // TODO : 공유 url을 어떻게 가져올 것인지 상의 필요.
+            String share = null;
+
+            RestaurantFeedListDTO.FeedDTO feedDTO =
+                    new RestaurantFeedListDTO.FeedDTO(feed, feedImageDTOS, likeCount, replyCount, share);
+
+            RestaurantFeedListDTO.RestaurantFeedsDTO restaurantFeedsDTO =
+                    new RestaurantFeedListDTO.RestaurantFeedsDTO(feedDTO, feedRestaurantDTO, isFollowed, isLiked);
+
+            restaurantFeedsDTOList.add(restaurantFeedsDTO);
+        }
+        return restaurantFeedsDTOList;
     }
 }

--- a/core/src/main/java/com/foodielog/server/feed/repository/FeedLikeRepository.java
+++ b/core/src/main/java/com/foodielog/server/feed/repository/FeedLikeRepository.java
@@ -5,7 +5,12 @@ import com.foodielog.server.feed.entity.FeedLike;
 import com.foodielog.server.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface FeedLikeRepository extends JpaRepository<FeedLike, Long> {
     boolean existsByUserAndFeed(User user, Feed feed);
+
     Long countByFeed(Feed feed);
+
+    Optional<FeedLike> findByUserId(Long id);
 }

--- a/core/src/main/java/com/foodielog/server/feed/repository/FeedRepository.java
+++ b/core/src/main/java/com/foodielog/server/feed/repository/FeedRepository.java
@@ -12,7 +12,11 @@ import java.util.List;
 public interface FeedRepository extends JpaRepository<Feed, Long> {
     Long countByUser(User user);
 
+    List<Feed> findByUserId(Long userId);
+
     @Query("SELECT f FROM Feed f " +
             "WHERE f.user = :user AND f.id > :feedId")
     List<Feed> getFeeds(@Param("user") User user, @Param("feedId") Long feedId, Pageable pageable);
+
+    List<Feed> findAllByRestaurantId(Long restaurantId);
 }

--- a/core/src/main/java/com/foodielog/server/restaurant/repository/RestaurantLikeRepository.java
+++ b/core/src/main/java/com/foodielog/server/restaurant/repository/RestaurantLikeRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RestaurantLikeRepository extends JpaRepository<RestaurantLike, Long> {
     boolean existsByUser(User user);
+
+    RestaurantLike findByUserIdAndRestaurantId(Long userId, Long restaurantId);
 }

--- a/core/src/main/java/com/foodielog/server/user/repository/FollowRepository.java
+++ b/core/src/main/java/com/foodielog/server/user/repository/FollowRepository.java
@@ -5,8 +5,14 @@ import com.foodielog.server.user.entity.FollowPK;
 import com.foodielog.server.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface FollowRepository extends JpaRepository<Follow, FollowPK> {
-	Long countByFollowedId(User followedId);
-	Long countByFollowingId(User followingId);
-	boolean existsByFollowedId(User user);
+    Long countByFollowedId(User followedId);
+
+    Long countByFollowingId(User followingId);
+
+    boolean existsByFollowedId(User user);
+
+    Optional<Follow> findByFollowingIdAndFollowedId(User following, User followed);
 }


### PR DESCRIPTION
## 요약
마이페이지 맛집 지도 리스트, 맛집 상세페이지 구현 완료

## 작업 내용
- [x] 마이페이지 유저의 맛집 리스트 구현
- [x] 맛집의 상세페이지 구현

## 참고 사항
피드 공유 Url 미처리
[카카오로 링크 공유하기 카카오 디벨로퍼 참고](https://developers.kakao.com/docs/latest/ko/message/common)

## 관련 이슈
Close #28 
