### PR TITLE
[Fix] #52 맛집 중복 체크 오류 수정

### DIFF
--- a/application/src/main/java/com/foodielog/application/feed/service/FeedService.java
+++ b/application/src/main/java/com/foodielog/application/feed/service/FeedService.java
@@ -32,7 +32,7 @@ public class FeedService {
     @Transactional
     public void save(FeedRequest.SaveDTO saveDTO, List<MultipartFile> files, User user) {
         Restaurant restaurant = dtoToRestaurant(saveDTO.getSelectedSearchPlace());
-        Restaurant savedRestaurant = isDuplicate(restaurant);
+        Restaurant savedRestaurant = saveRestaurant(restaurant);
 
         checkIsLiked(user, savedRestaurant, saveDTO);
 
@@ -60,7 +60,7 @@ public class FeedService {
         restaurantLikeRepository.save(restaurantLike);
     }
 
-    private Restaurant isDuplicate(Restaurant restaurant) {
+    private Restaurant saveRestaurant(Restaurant restaurant) {
         Optional<Restaurant> existingRestaurant =
                 restaurantRepository.findByKakaoPlaceId(restaurant.getKakaoPlaceId());
 


### PR DESCRIPTION
## 요약
맛집 중복 시 맛집 반환 오류 수정

발생원인

1. 맛집 중복 체크 시 해당 맛집이 db에 존재할 경우 반환되는 맛집이 명시되어 있지 않음.

## 작업 내용
- [x] isDuplicate() 반환값 수정

## 참고 사항

## 관련 이슈
Close #52 
