### PR TITLE
[Fix] #54 s3 이미지 삭제 오류 수정

### DIFF
--- a/core/src/main/java/com/foodielog/server/_core/s3/S3Uploader.java
+++ b/core/src/main/java/com/foodielog/server/_core/s3/S3Uploader.java
@@ -45,7 +45,7 @@ public class S3Uploader {
 
     public void deleteFile(String fileUrl) {
         String[] urlParts = fileUrl.split("/");
-        String fileBucket = urlParts[2].replace(".s3.amazonaws.com", "");
+        String fileBucket = urlParts[2].split("\\.")[0];
 
         if (!fileBucket.equals(bucket)) {
             throw new Exception400("fileUrl", ErrorMessage.NO_IMAGE_EXIST);
@@ -66,6 +66,8 @@ public class S3Uploader {
             log.error("AWS SDK client error : " + e.getMessage());
             throw new Exception500(ErrorMessage.FAIL_DELETE);
         }
+
+        log.info("File delete complete: " + objectKey);
     }
 
     private long parseMaxSize(String maxSizeString) {


### PR DESCRIPTION
## 요약
s3에서 이미지 삭제 중 해당 이미지를 찾지 못하는 오류 수정

발생원인

1. 이미지 삭제 과정 중 해당 이미지의 버킷명과 사용되는 버킷명이 다름

## 작업 내용
- [ ] 해당 이미지의 버킷명을 추출하는 코드 변경

## 참고 사항

## 관련 이슈
Close #54
