### PR TITLE
[Feat]  #58 알림 설정, 뱃지 신청 구현

### DIFF
--- a/application/src/main/java/com/foodielog/application/user/controller/UserSettingController.java
+++ b/application/src/main/java/com/foodielog/application/user/controller/UserSettingController.java
@@ -3,6 +3,7 @@ package com.foodielog.application.user.controller;
 import com.foodielog.application.user.dto.ChangeNotificationDTO;
 import com.foodielog.application.user.dto.ChangePasswordDTO;
 import com.foodielog.application.user.dto.ChangeProfileDTO;
+import com.foodielog.application.user.dto.CheckBadgeApplyDTO;
 import com.foodielog.application.user.service.UserSettingService;
 import com.foodielog.server._core.security.auth.PrincipalDetails;
 import com.foodielog.server._core.util.ApiUtils;
@@ -31,6 +32,13 @@ public class UserSettingController {
     ) {
         User user = principalDetails.getUser();
         ChangeNotificationDTO.Response response = userSettingService.changeNotification(user, request);
+        return new ResponseEntity<>(ApiUtils.success(response, HttpStatus.OK), HttpStatus.OK);
+    }
+
+    @GetMapping("/badge")
+    public ResponseEntity<?> checkBadgeApply(@AuthenticationPrincipal PrincipalDetails principalDetails) {
+        User user = principalDetails.getUser();
+        CheckBadgeApplyDTO.Response response = userSettingService.checkBadgeApply(user);
         return new ResponseEntity<>(ApiUtils.success(response, HttpStatus.OK), HttpStatus.OK);
     }
 

--- a/application/src/main/java/com/foodielog/application/user/controller/UserSettingController.java
+++ b/application/src/main/java/com/foodielog/application/user/controller/UserSettingController.java
@@ -1,5 +1,6 @@
 package com.foodielog.application.user.controller;
 
+import com.foodielog.application.user.dto.ChangeNotificationDTO;
 import com.foodielog.application.user.dto.ChangePasswordDTO;
 import com.foodielog.application.user.dto.ChangeProfileDTO;
 import com.foodielog.application.user.service.UserSettingService;
@@ -21,6 +22,17 @@ import javax.validation.Valid;
 @RestController
 public class UserSettingController {
     private final UserSettingService userSettingService;
+
+    @PutMapping("/notification")
+    public ResponseEntity<?> changeNotification(
+            @RequestBody @Valid ChangeNotificationDTO.Request request,
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            Error error
+    ) {
+        User user = principalDetails.getUser();
+        ChangeNotificationDTO.Response response = userSettingService.changeNotification(user, request);
+        return new ResponseEntity<>(ApiUtils.success(response, HttpStatus.OK), HttpStatus.OK);
+    }
 
     @PutMapping("/password")
     public ResponseEntity<?> changePassword(

--- a/application/src/main/java/com/foodielog/application/user/controller/UserSettingController.java
+++ b/application/src/main/java/com/foodielog/application/user/controller/UserSettingController.java
@@ -1,9 +1,6 @@
 package com.foodielog.application.user.controller;
 
-import com.foodielog.application.user.dto.ChangeNotificationDTO;
-import com.foodielog.application.user.dto.ChangePasswordDTO;
-import com.foodielog.application.user.dto.ChangeProfileDTO;
-import com.foodielog.application.user.dto.CheckBadgeApplyDTO;
+import com.foodielog.application.user.dto.*;
 import com.foodielog.application.user.service.UserSettingService;
 import com.foodielog.server._core.security.auth.PrincipalDetails;
 import com.foodielog.server._core.util.ApiUtils;
@@ -39,6 +36,13 @@ public class UserSettingController {
     public ResponseEntity<?> checkBadgeApply(@AuthenticationPrincipal PrincipalDetails principalDetails) {
         User user = principalDetails.getUser();
         CheckBadgeApplyDTO.Response response = userSettingService.checkBadgeApply(user);
+        return new ResponseEntity<>(ApiUtils.success(response, HttpStatus.OK), HttpStatus.OK);
+    }
+
+    @PostMapping("/badge")
+    public ResponseEntity<?> creatBadgeApplyDTO(@AuthenticationPrincipal PrincipalDetails principalDetails) {
+        User user = principalDetails.getUser();
+        CreateBadgeApplyDTO.Response response = userSettingService.creatBadgeApply(user);
         return new ResponseEntity<>(ApiUtils.success(response, HttpStatus.OK), HttpStatus.OK);
     }
 

--- a/application/src/main/java/com/foodielog/application/user/dto/ChangeNotificationDTO.java
+++ b/application/src/main/java/com/foodielog/application/user/dto/ChangeNotificationDTO.java
@@ -1,0 +1,25 @@
+package com.foodielog.application.user.dto;
+
+import com.foodielog.server._core.customValid.valid.ValidEnum;
+import com.foodielog.server.user.entity.User;
+import com.foodielog.server.user.type.Flag;
+import lombok.Getter;
+
+public class ChangeNotificationDTO {
+    @Getter
+    public static class Request {
+        @ValidEnum(enumClass = Flag.class)
+        private Flag flag;
+    }
+
+    @Getter
+    public static class Response {
+        private final String nickName;
+        private final Flag flag;
+
+        public Response(User user, Flag flag) {
+            this.nickName = user.getNickName();
+            this.flag = flag;
+        }
+    }
+}

--- a/application/src/main/java/com/foodielog/application/user/dto/CheckBadgeApplyDTO.java
+++ b/application/src/main/java/com/foodielog/application/user/dto/CheckBadgeApplyDTO.java
@@ -1,0 +1,22 @@
+package com.foodielog.application.user.dto;
+
+import com.foodielog.server.user.entity.User;
+import com.foodielog.server.user.type.Flag;
+import lombok.Getter;
+
+import java.sql.Timestamp;
+
+public class CheckBadgeApplyDTO {
+    @Getter
+    public static class Response {
+        private final String nickName;
+        private final Flag flag;
+        private final Timestamp createdAt;
+
+        public Response(User user, Timestamp createdAt) {
+            this.nickName = user.getNickName();
+            this.flag = createdAt != null ? Flag.Y : Flag.N;
+            this.createdAt = createdAt;
+        }
+    }
+}

--- a/application/src/main/java/com/foodielog/application/user/dto/CreateBadgeApplyDTO.java
+++ b/application/src/main/java/com/foodielog/application/user/dto/CreateBadgeApplyDTO.java
@@ -1,0 +1,20 @@
+package com.foodielog.application.user.dto;
+
+import com.foodielog.server.admin.entity.BadgeApply;
+import com.foodielog.server.user.entity.User;
+import lombok.Getter;
+
+import java.sql.Timestamp;
+
+public class CreateBadgeApplyDTO {
+    @Getter
+    public static class Response {
+        private final String nickName;
+        private final Timestamp createdAt;
+
+        public Response(User user, BadgeApply badgeApply) {
+            this.nickName = user.getNickName();
+            this.createdAt = badgeApply.getCreatedAt();
+        }
+    }
+}

--- a/application/src/main/java/com/foodielog/application/user/service/UserSettingService.java
+++ b/application/src/main/java/com/foodielog/application/user/service/UserSettingService.java
@@ -1,5 +1,6 @@
 package com.foodielog.application.user.service;
 
+import com.foodielog.application.user.dto.ChangeNotificationDTO;
 import com.foodielog.application.user.dto.ChangePasswordDTO;
 import com.foodielog.application.user.dto.ChangeProfileDTO;
 import com.foodielog.server._core.error.ErrorMessage;
@@ -21,6 +22,14 @@ public class UserSettingService {
     private final PasswordEncoder passwordEncoder;
     private final S3Uploader s3Uploader;
     private final UserRepository userRepository;
+
+    @Transactional
+    public ChangeNotificationDTO.Response changeNotification(User user, ChangeNotificationDTO.Request request) {
+        user.changeNotificationFlag(request.getFlag());
+        userRepository.save(user);
+
+        return new ChangeNotificationDTO.Response(user, request.getFlag());
+    }
 
     @Transactional
     public ChangePasswordDTO.Response changePassword(User user, ChangePasswordDTO.Request request) {

--- a/application/src/main/java/com/foodielog/application/user/service/UserSettingService.java
+++ b/application/src/main/java/com/foodielog/application/user/service/UserSettingService.java
@@ -3,9 +3,12 @@ package com.foodielog.application.user.service;
 import com.foodielog.application.user.dto.ChangeNotificationDTO;
 import com.foodielog.application.user.dto.ChangePasswordDTO;
 import com.foodielog.application.user.dto.ChangeProfileDTO;
+import com.foodielog.application.user.dto.CheckBadgeApplyDTO;
 import com.foodielog.server._core.error.ErrorMessage;
 import com.foodielog.server._core.error.exception.Exception400;
 import com.foodielog.server._core.s3.S3Uploader;
+import com.foodielog.server.admin.entity.BadgeApply;
+import com.foodielog.server.admin.repository.BadgeApplyRepository;
 import com.foodielog.server.user.entity.User;
 import com.foodielog.server.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +18,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.sql.Timestamp;
+
 @Slf4j
 @RequiredArgsConstructor
 @Service
@@ -22,6 +27,7 @@ public class UserSettingService {
     private final PasswordEncoder passwordEncoder;
     private final S3Uploader s3Uploader;
     private final UserRepository userRepository;
+    private final BadgeApplyRepository badgeApplyRepository;
 
     @Transactional
     public ChangeNotificationDTO.Response changeNotification(User user, ChangeNotificationDTO.Request request) {
@@ -29,6 +35,15 @@ public class UserSettingService {
         userRepository.save(user);
 
         return new ChangeNotificationDTO.Response(user, request.getFlag());
+    }
+
+    @Transactional(readOnly = true)
+    public CheckBadgeApplyDTO.Response checkBadgeApply(User user) {
+        Timestamp createdAt = badgeApplyRepository.findByUserId(user.getId())
+                .map(BadgeApply::getCreatedAt)
+                .orElseGet(() -> null);
+
+        return new CheckBadgeApplyDTO.Response(user, createdAt);
     }
 
     @Transactional
@@ -44,6 +59,7 @@ public class UserSettingService {
         return new ChangePasswordDTO.Response(user.getEmail());
     }
 
+    @Transactional
     public ChangeProfileDTO.Response ChangeProfile(User user, ChangeProfileDTO.Request request, MultipartFile file) {
         // 기존 닉네임과 일치 하지 않은데 중복이라면 중복! (기존 닉네임과 동일 하다면 닉네임을 변경 하는게 아님)
         if (!user.getNickName().equals(request.getNickName())

--- a/application/src/main/java/com/foodielog/application/user/service/UserSettingService.java
+++ b/application/src/main/java/com/foodielog/application/user/service/UserSettingService.java
@@ -1,9 +1,6 @@
 package com.foodielog.application.user.service;
 
-import com.foodielog.application.user.dto.ChangeNotificationDTO;
-import com.foodielog.application.user.dto.ChangePasswordDTO;
-import com.foodielog.application.user.dto.ChangeProfileDTO;
-import com.foodielog.application.user.dto.CheckBadgeApplyDTO;
+import com.foodielog.application.user.dto.*;
 import com.foodielog.server._core.error.ErrorMessage;
 import com.foodielog.server._core.error.exception.Exception400;
 import com.foodielog.server._core.s3.S3Uploader;
@@ -44,6 +41,14 @@ public class UserSettingService {
                 .orElseGet(() -> null);
 
         return new CheckBadgeApplyDTO.Response(user, createdAt);
+    }
+
+    @Transactional
+    public CreateBadgeApplyDTO.Response creatBadgeApply(User user) {
+        BadgeApply badgeApply = BadgeApply.createBadgeApply(user);
+        badgeApplyRepository.save(badgeApply);
+
+        return new CreateBadgeApplyDTO.Response(user, badgeApply);
     }
 
     @Transactional

--- a/core/src/main/java/com/foodielog/server/_core/customValid/valid/ValidEnum.java
+++ b/core/src/main/java/com/foodielog/server/_core/customValid/valid/ValidEnum.java
@@ -1,0 +1,21 @@
+package com.foodielog.server._core.customValid.valid;
+
+import com.foodielog.server._core.customValid.validator.EnumValidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = EnumValidator.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidEnum {
+    String message() default "정의 되지 않은 입력 입니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    Class<? extends java.lang.Enum<?>> enumClass();
+}

--- a/core/src/main/java/com/foodielog/server/_core/customValid/validator/EnumValidator.java
+++ b/core/src/main/java/com/foodielog/server/_core/customValid/validator/EnumValidator.java
@@ -1,0 +1,32 @@
+package com.foodielog.server._core.customValid.validator;
+
+import com.foodielog.server._core.customValid.valid.ValidEnum;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class EnumValidator implements ConstraintValidator<ValidEnum, Enum> {
+    private ValidEnum annotation;
+
+    @Override
+    public void initialize(ValidEnum constraintAnnotation) {
+        this.annotation = constraintAnnotation;
+    }
+
+    @Override
+    public boolean isValid(Enum value, ConstraintValidatorContext context) {
+        boolean result = false;
+
+        Object[] enumValues = this.annotation.enumClass().getEnumConstants();
+        if (enumValues != null) {
+            for (Object enumValue : enumValues) {
+                if (value == enumValue) {
+                    result = true;
+                    break;
+                }
+            }
+        }
+        return result;
+    }
+}
+

--- a/core/src/main/java/com/foodielog/server/_core/error/MyExceptionHandler.java
+++ b/core/src/main/java/com/foodielog/server/_core/error/MyExceptionHandler.java
@@ -44,9 +44,14 @@ public class MyExceptionHandler {
 
     // @Validated 예외 처리
     @ExceptionHandler(ConstraintViolationException.class)
-    public ResponseEntity<?> inValid(ConstraintViolationException e) {
+    public ResponseEntity<?> inValidParam(ConstraintViolationException e) {
         ApiUtils.ApiResult<?> apiResult = ApiUtils.error(e.getMessage(), HttpStatus.BAD_REQUEST);
         return new ResponseEntity<>(apiResult, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(ValidationException.class)
+    public ResponseEntity<?> inValid(ValidationException e) {
+        return new ResponseEntity<>(e.body(), HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(Exception.class)

--- a/core/src/main/java/com/foodielog/server/admin/entity/BadgeApply.java
+++ b/core/src/main/java/com/foodielog/server/admin/entity/BadgeApply.java
@@ -1,47 +1,44 @@
 package com.foodielog.server.admin.entity;
 
-import java.sql.Timestamp;
-
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
-
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
-
 import com.foodielog.server.admin.type.ProcessedStatus;
 import com.foodielog.server.user.entity.User;
-
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import javax.persistence.*;
+import java.sql.Timestamp;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Table(name = "badge_apply_tb")
 @Entity
 public class BadgeApply {
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "user_id")
-	private User user;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
 
-	@Enumerated(EnumType.STRING)
-	private ProcessedStatus status;
+    @Enumerated(EnumType.STRING)
+    @ColumnDefault("'UNPROCESSED'")
+    private ProcessedStatus status;
 
-	@CreationTimestamp
-	private Timestamp createdAt;
+    @CreationTimestamp
+    private Timestamp createdAt;
 
-	@UpdateTimestamp
-	private Timestamp updatedAt;
+    @UpdateTimestamp
+    private Timestamp updatedAt;
+
+    public static BadgeApply createBadgeApply(User user) {
+        BadgeApply badgeApply = new BadgeApply();
+        badgeApply.user = user;
+
+        return badgeApply;
+    }
 }

--- a/core/src/main/java/com/foodielog/server/admin/repository/BadgeApplyRepository.java
+++ b/core/src/main/java/com/foodielog/server/admin/repository/BadgeApplyRepository.java
@@ -1,0 +1,12 @@
+package com.foodielog.server.admin.repository;
+
+import com.foodielog.server.admin.entity.BadgeApply;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface BadgeApplyRepository extends JpaRepository<BadgeApply, Long> {
+
+    Optional<BadgeApply> findByUserId(Long id);
+
+}

--- a/core/src/main/java/com/foodielog/server/user/entity/User.java
+++ b/core/src/main/java/com/foodielog/server/user/entity/User.java
@@ -90,6 +90,10 @@ public class User {
         return user;
     }
 
+    public void changeNotificationFlag(Flag flag) {
+        this.notificationFlag = flag;
+    }
+
     public void resetPassword(String password) {
         this.password = password;
     }


### PR DESCRIPTION
## 요약
알림 설정, 뱃지 신청 구현

## 작업 내용
- [X] 알림 on/off
- [X] 뱃지 신청 내역(Y/N) 조회
- [X]  뱃지 신청

## 참고 사항
이미 신청 내역이 있는지 확인 후 신청하도록 해야할듯 해서
"뱃지 신청 내역(Y/N) 조회" api 추가함

그런데 이미 뱃지가 있는 사람이 신청할경우도 핸들링 해야할듯 함
뱃지 상태를 확인하는 api 추가 필요해보임

\* 커스텀 Valid을 RequestBody에서 사용 시 exception 핸들링이 안되는듯 함... 500 에러로 던져짐... 아직 해결 못함  
## 관련 이슈
Close #58
