### PR TITLE
[Feat] #91 메인 피드 기능 구현

### DIFF
--- a/application/src/main/java/com/foodielog/application/feed/controller/FeedController.java
+++ b/application/src/main/java/com/foodielog/application/feed/controller/FeedController.java
@@ -4,6 +4,7 @@ import com.foodielog.application.feed.dto.FeedSaveDTO;
 import com.foodielog.application.feed.dto.LikeFeedDTO;
 import com.foodielog.application.feed.dto.ReportFeedDTO;
 import com.foodielog.application.feed.dto.UpdateFeedDTO;
+import com.foodielog.application.feed.dto.MainFeedListDTO;
 import com.foodielog.application.feed.service.FeedService;
 import com.foodielog.server._core.error.ErrorMessage;
 import com.foodielog.server._core.error.exception.Exception400;
@@ -14,6 +15,8 @@ import com.foodielog.server._core.util.ApiUtils;
 import com.foodielog.server.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -25,6 +28,7 @@ import org.springframework.web.multipart.MultipartFile;
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Positive;
+import javax.validation.constraints.PositiveOrZero;
 import java.util.List;
 
 @Slf4j
@@ -112,5 +116,15 @@ public class FeedController {
         User user = principalDetails.getUser();
         feedService.reportFeed(user, request);
         return new ResponseEntity<>(ApiUtils.success(null, HttpStatus.OK), HttpStatus.OK);
+    }
+
+    @GetMapping("/list")
+    public ResponseEntity<ApiUtils.ApiResult<MainFeedListDTO.Response>> list(
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @RequestParam @PositiveOrZero Long feedId,
+            @PageableDefault(size = 15) Pageable pageable
+    ) {
+        MainFeedListDTO.Response response = feedService.getMainFeed(principalDetails.getUser(), feedId, pageable);
+        return new ResponseEntity<>(ApiUtils.success(response, HttpStatus.OK), HttpStatus.OK);
     }
 }

--- a/application/src/main/java/com/foodielog/application/feed/dto/MainFeedListDTO.java
+++ b/application/src/main/java/com/foodielog/application/feed/dto/MainFeedListDTO.java
@@ -1,0 +1,88 @@
+package com.foodielog.application.feed.dto;
+
+import com.foodielog.server.feed.entity.Feed;
+import com.foodielog.server.feed.entity.Media;
+import com.foodielog.server.restaurant.entity.Restaurant;
+import lombok.Getter;
+
+import java.sql.Timestamp;
+import java.util.List;
+
+public class MainFeedListDTO {
+    @Getter
+    public static class Response {
+        private final List<MainFeedsDTO> content;
+
+        public Response(List<MainFeedsDTO> content) {
+            this.content = content;
+        }
+    }
+
+    @Getter
+    public static class MainFeedsDTO {
+        private final FeedDTO feed;
+        private final MainFeedRestaurantDTO restaurant;
+        private final boolean isFollowed;
+        private final boolean isLiked;
+
+        public MainFeedsDTO(FeedDTO feed, MainFeedRestaurantDTO restaurant, boolean isFollowed, boolean isLiked) {
+            this.feed = feed;
+            this.restaurant = restaurant;
+            this.isFollowed = isFollowed;
+            this.isLiked = isLiked;
+        }
+    }
+
+    @Getter
+    public static class FeedDTO {
+        private final String nickName;
+        private final String profileImageUrl;
+        private final Long feedId;
+        private final Timestamp createdAt;
+        private final Timestamp updatedAt;
+        private final List<FeedImageDTO> feedImages;
+        private final String content;
+        private final Long likeCount;
+        private final Long replyCount;
+        private final String share;
+
+        public FeedDTO(Feed feed, List<FeedImageDTO> feedImages, Long likeCount, Long replyCount, String share) {
+            this.nickName = feed.getUser().getNickName();
+            this.profileImageUrl = feed.getUser().getProfileImageUrl();
+            this.feedId = feed.getId();
+            this.createdAt = feed.getCreatedAt();
+            this.updatedAt = feed.getUpdatedAt();
+            this.feedImages = feedImages;
+            this.content = feed.getContent();
+            this.likeCount = likeCount;
+            this.replyCount = replyCount;
+            this.share = share;
+        }
+    }
+
+    @Getter
+    public static class FeedImageDTO {
+        private final String imageUrl;
+
+        public FeedImageDTO(Media media) {
+            this.imageUrl = media.getImageUrl();
+        }
+    }
+
+    @Getter
+    public static class MainFeedRestaurantDTO {
+        private final Long id;
+        private final String name;
+        private final String category;
+        private final String link;
+        private final String roadAddress;
+
+        public MainFeedRestaurantDTO(Restaurant restaurant) {
+            this.id = restaurant.getId();
+            this.name = restaurant.getName();
+            this.category = restaurant.getCategory();
+            this.link = restaurant.getLink();
+            this.roadAddress = restaurant.getRoadAddress();
+        }
+    }
+}

--- a/application/src/main/java/com/foodielog/application/feed/service/FeedService.java
+++ b/application/src/main/java/com/foodielog/application/feed/service/FeedService.java
@@ -1,8 +1,8 @@
 package com.foodielog.application.feed.service;
 
 import com.foodielog.application.feed.dto.FeedSaveDTO;
-import com.foodielog.application.feed.dto.ReportFeedDTO;
 import com.foodielog.application.feed.dto.MainFeedListDTO;
+import com.foodielog.application.feed.dto.ReportFeedDTO;
 import com.foodielog.application.feed.dto.UpdateFeedDTO;
 import com.foodielog.server._core.error.exception.Exception403;
 import com.foodielog.server._core.error.exception.Exception404;
@@ -26,7 +26,6 @@ import com.foodielog.server.restaurant.repository.RestaurantLikeRepository;
 import com.foodielog.server.restaurant.repository.RestaurantRepository;
 import com.foodielog.server.user.entity.User;
 import com.foodielog.server.user.repository.FollowRepository;
-import com.google.type.Date;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;

--- a/core/src/main/java/com/foodielog/server/feed/repository/FeedLikeRepository.java
+++ b/core/src/main/java/com/foodielog/server/feed/repository/FeedLikeRepository.java
@@ -15,4 +15,6 @@ public interface FeedLikeRepository extends JpaRepository<FeedLike, Long> {
     Long countByFeed(Feed feed);
 
     Optional<FeedLike> findByUserId(Long id);
+
+    boolean existsByUser(User user);
 }

--- a/core/src/main/java/com/foodielog/server/feed/repository/FeedRepository.java
+++ b/core/src/main/java/com/foodielog/server/feed/repository/FeedRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.sql.Timestamp;
 import java.util.List;
 import java.util.Optional;
 
@@ -34,4 +35,12 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
     List<Feed> findTop3ByRestaurantId(Long restaurantId, Pageable pageable);
 
     Optional<Feed> findByIdAndStatus(Long feedId, ContentStatus status);
+
+    @Query("SELECT f FROM Feed f " +
+            "LEFT JOIN Follow fo ON f.user = fo.followedId AND fo.followingId = :user " +
+            "WHERE (fo.followedId IS NOT NULL " +
+            "OR f.id IN (SELECT li.feed FROM FeedLike li WHERE li.feed.id > :feedId GROUP BY li.feed HAVING COUNT(li.feed) >= :likeCount)) " +
+            "AND f.status = 'NORMAL' AND f.createdAt >= :date ")
+    List<Feed> getMainFeed(@Param("user") User user, @Param("feedId") Long feedId,
+                           @Param("likeCount") Long likeCount, @Param("date") Timestamp date, Pageable pageable);
 }


### PR DESCRIPTION
## 요약
- 메인 피드 구현

## 작업 내용
- [x] 메인 피드 구현

## 참고 사항
```Java
public MainFeedListDTO.Response getMainFeed(User user, Long feedId, Pageable pageable) {
        LocalDateTime now = LocalDateTime.now();
        LocalDateTime date = now.minusMonths(1);

        List<Feed> mainFeeds = feedRepository.getMainFeed(user, feedId, 0L, Timestamp.valueOf(date), pageable);
}
```
- 한달 전 피드까지 가져오도록 기능을 구현
- feedId 에 대한 validation 은 `Multi Thread` 환경에서 삭제가 되어 피드가 검색이 안되는 현상이 있어 제거
    - findById 와 같이 status 검색을 하지 않고 가능은 한 것으로 보이지만 페이징을 위한 Id 이며 validation 의 필요성이 안느껴져서 제거

## 관련 이슈
Close #91 
