### PR TITLE
[Fix] kakao login API 오류  

### DIFF
--- a/application/src/main/java/com/foodielog/application/user/controller/UserAuthController.java
+++ b/application/src/main/java/com/foodielog/application/user/controller/UserAuthController.java
@@ -113,11 +113,9 @@ public class UserAuthController {
 
     @GetMapping("/login/kakao")
     public ResponseEntity<ApiUtils.ApiResult<KakaoLoginResp>> kakaoLogin(
-            @RequestParam String code
+            @RequestParam String token
     ) {
-        log.info("kakao 인가 code : " + code);
-
-        KakaoLoginResp response = oauthUserService.kakaoLogin(code);
+        KakaoLoginResp response = oauthUserService.kakaoLogin(token);
 
         HttpHeaders headers = getCookieHeaders(response.getRefreshToken());
 

--- a/application/src/main/java/com/foodielog/application/user/dto/response/KakaoLoginResp.java
+++ b/application/src/main/java/com/foodielog/application/user/dto/response/KakaoLoginResp.java
@@ -26,16 +26,6 @@ public class KakaoLoginResp {
 
     public static class kakaoApiResp {
         @Getter
-        public static class Token {
-            private String accessToken;
-            private String tokenType;
-            private String refreshToken;
-            private int expiresIn;
-            private String scope;
-            private int refreshTokenExpiresIn;
-        }
-
-        @Getter
         public static class UserInfo {
             private Long id;
             private String connectedAt;

--- a/application/src/main/java/com/foodielog/application/user/service/UserOauthService.java
+++ b/application/src/main/java/com/foodielog/application/user/service/UserOauthService.java
@@ -63,9 +63,6 @@ public class UserOauthService {
         String accessToken = jwtTokenProvider.createAccessToken(loginUser);
         String refreshToken = jwtTokenProvider.createRefreshToken(loginUser);
 
-        log.info("kakao 엑세스 토큰 생성 완료: " + accessToken);
-        log.info("kakao 리프레시 토큰 생성 완료: " + refreshToken);
-
         // 리프레시 토큰  Redis에 저장 ( key = "RT " + Email / value = refreshToken )
         redisService.setObjectByKey(RedisService.REFRESH_TOKEN_PREFIX + loginUser.getEmail(), refreshToken,
                 JwtTokenProvider.EXP_REFRESH, TimeUnit.MILLISECONDS);
@@ -77,6 +74,7 @@ public class UserOauthService {
         ResponseEntity<String> userInfoResponse = ExternalUtil.kakaoUserInfoRequest(KAKAO_USER_INFO_URI, HttpMethod.POST, token);
 
         if (!userInfoResponse.getStatusCode().equals(HttpStatus.OK)) {
+            log.error("카카오 로그인: " + userInfoResponse.getBody());
             throw new Exception500(userInfoResponse.getBody());
         }
 

--- a/application/src/main/resources/application-api.yml
+++ b/application/src/main/resources/application-api.yml
@@ -1,10 +1,6 @@
 # KaKao
 kakao:
   login:
-    redirect-uri: "http://localhost:8080/auth/kakao/callback"
-    grant-type: "authorization_code"
-    authorization-uri: "https://kauth.kakao.com/oauth/authorize"
-    token-uri: "https://kauth.kakao.com/oauth/token"
     user-info-uri: "https://kapi.kakao.com/v2/user/me"
     user-name-attribute: "id"
 

--- a/application/src/test/resources/application-api.yml
+++ b/application/src/test/resources/application-api.yml
@@ -1,10 +1,6 @@
 # KaKao
 kakao:
   login:
-    redirect-uri: "http://localhost:8080/auth/kakao/callback"
-    grant-type: "authorization_code"
-    authorization-uri: "https://kauth.kakao.com/oauth/authorize"
-    token-uri: "https://kauth.kakao.com/oauth/token"
     user-info-uri: "https://kapi.kakao.com/v2/user/me"
     user-name-attribute: "id"
 

--- a/management/src/main/resources/application-api.yml
+++ b/management/src/main/resources/application-api.yml
@@ -1,10 +1,6 @@
 # KaKao
 kakao:
   login:
-    redirect-uri: "http://localhost:8080/auth/kakao/callback"
-    grant-type: "authorization_code"
-    authorization-uri: "https://kauth.kakao.com/oauth/authorize"
-    token-uri: "https://kauth.kakao.com/oauth/token"
     user-info-uri: "https://kapi.kakao.com/v2/user/me"
     user-name-attribute: "id"
 

--- a/management/src/test/resources/application-api.yml
+++ b/management/src/test/resources/application-api.yml
@@ -1,10 +1,6 @@
 # KaKao
 kakao:
   login:
-    redirect-uri: "http://localhost:8080/auth/kakao/callback"
-    grant-type: "authorization_code"
-    authorization-uri: "https://kauth.kakao.com/oauth/authorize"
-    token-uri: "https://kauth.kakao.com/oauth/token"
     user-info-uri: "https://kapi.kakao.com/v2/user/me"
     user-name-attribute: "id"
 


### PR DESCRIPTION
## 요약
카카오 로그인 api 호출 시,
인가 코드 발급 리다이렉트 url과 토큰 발급 리다이렉트 url 이 일치해야한다는 조건이 있었음
현재는 인가 코드는 프론트 서버에서, 토큰은 백엔드 서버에서 발급하는 로직이라 토큰 발급 api 호출에서 에러가 발생

따라서 프론트에서 [인가코드 발급 -> 토큰 발급] 후 토큰을 백엔드에 전달하는 로직으로 변경

## 작업 내용

- [x] 카카오 토큰 발급 코드 제거
- [x] auth/login/kakao 요청값 코드 ->  토큰으로 변경
- [x] 외부 API로 인한 500번 에러는 서버에 로그로 남기도록 추가

## 참고 사항

## 관련 이슈
Close #109 
