### PR TITLE
[Fix] #127, #128 follow 값 에러 및 like 값 에러 수정

### DIFF
--- a/application/src/main/java/com/foodielog/application/feed/service/FeedService.java
+++ b/application/src/main/java/com/foodielog/application/feed/service/FeedService.java
@@ -213,8 +213,8 @@ public class FeedService {
             MainFeedListResp.FeedDTO feedDTO = getFeedDTO(mainFeed, feedImageDTO);
             MainFeedListResp.MainFeedRestaurantDTO mainFeedRestaurantDTO = getUserRestaurantDTO(mainFeed);
 
-            boolean isFollowed = followRepository.existsByFollowedId(user);
-            boolean isLiked = feedLikeRepository.existsByUser(user);
+            boolean isFollowed = followRepository.existsByFollowingIdAndFollowedId(user, mainFeed.getUser());
+            boolean isLiked = feedLikeRepository.existsByUserAndFeed(user, mainFeed);
 
             mainFeedDTOList.add(new MainFeedListResp.MainFeedsDTO(feedDTO, mainFeedRestaurantDTO, isFollowed, isLiked));
         }

--- a/application/src/main/java/com/foodielog/application/restaurant/service/RestaurantService.java
+++ b/application/src/main/java/com/foodielog/application/restaurant/service/RestaurantService.java
@@ -147,7 +147,7 @@ public class RestaurantService {
             Long replyCount = replyRepository.countByFeedAndStatus(feed, ContentStatus.NORMAL);
 
             boolean isFollowed = followRepository.existsByFollowingIdAndFollowedId(user, feed.getUser());
-            boolean isLiked = feedLikeRepository.existsByUser(user);
+            boolean isLiked = feedLikeRepository.existsByUserAndFeed(user, feed);
 
             RestaurantFeedListResp.FeedDTO feedDTO =
                     new RestaurantFeedListResp.FeedDTO(feed, feedImageDTOS, likeCount, replyCount);

--- a/application/src/main/java/com/foodielog/application/user/service/UserService.java
+++ b/application/src/main/java/com/foodielog/application/user/service/UserService.java
@@ -77,8 +77,8 @@ public class UserService {
             UserFeedListResp.FeedDTO feedDTO = getFeedDTO(feed, feedImages);
             UserFeedListResp.UserRestaurantDTO userRestaurantDTO = getUserRestaurantDTO(feed);
 
-            boolean isFollowed = followRepository.existsByFollowedId(user);
-            boolean isLiked = feedLikeRepository.existsByUser(user);
+            boolean isFollowed = followRepository.existsByFollowingIdAndFollowedId(user, feed.getUser());
+            boolean isLiked = feedLikeRepository.existsByUserAndFeed(user, feed);
 
             userFeedsDTOList.add(new UserFeedListResp.UserFeedsDTO(feedDTO, userRestaurantDTO, isFollowed, isLiked));
         }

--- a/core/src/main/java/com/foodielog/server/feed/repository/FeedLikeRepository.java
+++ b/core/src/main/java/com/foodielog/server/feed/repository/FeedLikeRepository.java
@@ -15,6 +15,4 @@ public interface FeedLikeRepository extends JpaRepository<FeedLike, Long> {
     Long countByFeed(Feed feed);
 
     Optional<FeedLike> findByUserId(Long id);
-
-    boolean existsByUser(User user);
 }

--- a/core/src/main/java/com/foodielog/server/feed/repository/FeedRepository.java
+++ b/core/src/main/java/com/foodielog/server/feed/repository/FeedRepository.java
@@ -38,7 +38,7 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
             "LEFT JOIN Follow fo ON f.user = fo.followedId AND fo.followingId = :user " +
             "WHERE (fo.followedId IS NOT NULL " +
             "OR f.id IN (SELECT li.feed FROM FeedLike li WHERE li.feed.id > :feedId GROUP BY li.feed HAVING COUNT(li.feed) >= :likeCount)) " +
-            "AND f.status = 'NORMAL' AND f.createdAt >= :date ")
+            "AND f.status = 'NORMAL' AND f.createdAt >= :date AND f.user != :user")
     List<Feed> getMainFeed(@Param("user") User user, @Param("feedId") Long feedId,
                            @Param("likeCount") Long likeCount, @Param("date") Timestamp date, Pageable pageable);
 }

--- a/core/src/main/java/com/foodielog/server/user/repository/FollowRepository.java
+++ b/core/src/main/java/com/foodielog/server/user/repository/FollowRepository.java
@@ -12,8 +12,6 @@ public interface FollowRepository extends JpaRepository<Follow, FollowPK> {
 
     Long countByFollowingId(User followingId);
 
-    boolean existsByFollowedId(User user);
-
     Optional<Follow> findByFollowingIdAndFollowedId(User following, User followed);
 
     boolean existsByFollowingIdAndFollowedId(User following, User followed);


### PR DESCRIPTION
## 요약
- 피드 리스트 follow 값과 like 값 에러 사항 수정
- 메인 피드 자신의 피드까지 가져오는 부분 수정

## 작업 내용
- [x] follow, like 수정
- [x] 메인 피드 sql 문 수정

## 참고 사항

## 관련 이슈
Close #127 , #128 
