### PR TITLE
[Fix] #131 신고 횟수 카운트 쿼리 수정

### DIFF
--- a/core/src/main/java/com/foodielog/server/report/repository/ReportRepository.java
+++ b/core/src/main/java/com/foodielog/server/report/repository/ReportRepository.java
@@ -14,11 +14,9 @@ import java.util.Optional;
 public interface ReportRepository extends JpaRepository<Report, Long> {
     boolean existsByReporterIdAndTypeAndContentId(User reporterId, ReportType type, Long contentId);
 
-    @Query("SELECT COUNT(DISTINCT r) FROM Report r " +
-            "WHERE r.reportedId = :reportedId " +
-            "AND r.contentId = :contentId " +
-            "AND r.status = :status")
-    long countProcessedByStatus(@Param("reportedId") User reportedId, @Param("contentId") Long contentId, @Param("status") ProcessedStatus status);
+    @Query("SELECT COUNT(DISTINCT r.contentId) FROM Report r " +
+            "WHERE r.reportedId = :reportedId AND r.status = :status")
+    long countProcessedByStatus(@Param("reportedId") User reportedId, @Param("status") ProcessedStatus status);
 
     Optional<List<Report>> findAllByReportedIdAndContentId(User reportedId, Long contentId);
 }

--- a/management/src/main/java/com/foodielog/management/report/service/ReportService.java
+++ b/management/src/main/java/com/foodielog/management/report/service/ReportService.java
@@ -50,9 +50,7 @@ public class ReportService {
                 sendProcessedMail(reportedUser, reportList);
 
                 // 10 회 초과 시 자동 차단
-                if (10L < reportRepository.countProcessedByStatus(
-                        reportedUser, request.getContentId(), ProcessedStatus.APPROVED)
-                ) {
+                if (10L < reportRepository.countProcessedByStatus(reportedUser, ProcessedStatus.APPROVED)) {
                     blockUser(reportedUser);
                 }
 


### PR DESCRIPTION
## 요약
'신고 승인 10 회 초과 시 자동 차단' 기능에서 신고 횟수 카운트 하는 쿼리문 오류

## 작업 내용
- [x] 쿼리 수정

## 참고 사항
contentId를 받아서 조건에 넣는게 아니라 count 에서 중복 제거 조건을 r.contentId로 지정해야 함

## 관련 이슈
Close #131
