### PR TITLE
[Feat] #133 회원 목록 조회 및 영구 차단 구현

### DIFF
--- a/core/src/main/java/com/foodielog/server/_core/customValid/valid/ValidEnum.java
+++ b/core/src/main/java/com/foodielog/server/_core/customValid/valid/ValidEnum.java
@@ -18,4 +18,6 @@ public @interface ValidEnum {
     Class<? extends Payload>[] payload() default {};
 
     Class<? extends java.lang.Enum<?>> enumClass();
+
+    boolean nullable() default false;
 }

--- a/core/src/main/java/com/foodielog/server/_core/customValid/validator/EnumValidator.java
+++ b/core/src/main/java/com/foodielog/server/_core/customValid/validator/EnumValidator.java
@@ -17,6 +17,11 @@ public class EnumValidator implements ConstraintValidator<ValidEnum, Enum> {
     public boolean isValid(Enum value, ConstraintValidatorContext context) {
         boolean result = false;
 
+        boolean nullable = this.annotation.nullable();
+        if (nullable) {
+            return true;
+        }
+
         Object[] enumValues = this.annotation.enumClass().getEnumConstants();
         if (enumValues != null) {
             for (Object enumValue : enumValues) {

--- a/core/src/main/java/com/foodielog/server/admin/entity/BlockUser.java
+++ b/core/src/main/java/com/foodielog/server/admin/entity/BlockUser.java
@@ -24,6 +24,7 @@ public class BlockUser {
     @JoinColumn(name = "user_id")
     private User user;
 
+    @Column(length = 100)
     private String reason;
 
     @Column(name = "feed_count")
@@ -39,6 +40,16 @@ public class BlockUser {
         BlockUser blockUser = new BlockUser();
         blockUser.user = user;
         blockUser.reason = "신고 승인 횟수 10번 초과";
+        blockUser.feedCount = feedCount;
+        blockUser.replyCount = replyCount;
+
+        return blockUser;
+    }
+
+    public static BlockUser createBlock(User user, String reason, Long feedCount, Long replyCount) {
+        BlockUser blockUser = new BlockUser();
+        blockUser.user = user;
+        blockUser.reason = reason;
         blockUser.feedCount = feedCount;
         blockUser.replyCount = replyCount;
 

--- a/core/src/main/java/com/foodielog/server/user/repository/UserRepository.java
+++ b/core/src/main/java/com/foodielog/server/user/repository/UserRepository.java
@@ -1,11 +1,14 @@
 package com.foodielog.server.user.repository;
 
 import com.foodielog.server.user.entity.User;
+import com.foodielog.server.user.type.Flag;
 import com.foodielog.server.user.type.Role;
 import com.foodielog.server.user.type.UserStatus;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.security.core.parameters.P;
 
 import java.util.List;
 import java.util.Optional;
@@ -27,4 +30,11 @@ public interface UserRepository extends JpaRepository<User, Long> {
             "GROUP BY u " +
             "ORDER BY COUNT(f.followingId) DESC")
     List<User> searchUserOrderByFollowedIdDesc(@Param("keyword") String keyword);
+
+    @Query("SELECT u FROM User u " +
+            "WHERE (:nickName IS NULL OR u.nickName LIKE %:nickName%) " +
+            "AND (:badgeFlag IS NULL OR u.badgeFlag = :badgeFlag) " +
+            "AND ((:status IS NULL AND (u.status = 'NORMAL' OR u.status = 'BLOCK')) OR u.status = :status) ")
+    List<User> findAllByFlagAndStatus(@Param("nickName") String nickName, @Param("badgeFlag") Flag badgeFlag,
+                                      @Param("status") UserStatus status, Pageable pageable);
 }

--- a/management/src/main/java/com/foodielog/management/member/controller/MemberController.java
+++ b/management/src/main/java/com/foodielog/management/member/controller/MemberController.java
@@ -67,8 +67,8 @@ public class MemberController {
     @GetMapping("/list")
     public ResponseEntity<ApiUtils.ApiResult<MemberListResp>> memberList(
             @RequestParam(required = false) String nickName,
-            @RequestParam(required = false) Flag badge,
-            @RequestParam(required = false) UserStatus userStatus,
+            @RequestParam(required = false) @ValidEnum(enumClass = Flag.class, nullable = true) Flag badge,
+            @RequestParam(required = false) @ValidEnum(enumClass = UserStatus.class, nullable = true) UserStatus userStatus,
             @PageableDefault(size = 20) Pageable pageable
     ) {
         MemberListResp response = memberService.getMemberList(nickName, badge, userStatus, pageable);

--- a/management/src/main/java/com/foodielog/management/member/controller/MemberController.java
+++ b/management/src/main/java/com/foodielog/management/member/controller/MemberController.java
@@ -1,12 +1,14 @@
 package com.foodielog.management.member.controller;
 
 import com.foodielog.management.member.dto.response.BadgeApplyListResp;
+import com.foodielog.management.member.dto.response.MemberListResp;
 import com.foodielog.management.member.dto.response.WithdrawListResp;
 import com.foodielog.management.member.service.MemberService;
 import com.foodielog.server._core.customValid.valid.ValidEnum;
 import com.foodielog.server._core.util.ApiUtils;
 import com.foodielog.server.admin.type.ProcessedStatus;
 import com.foodielog.server.user.type.Flag;
+import com.foodielog.server.user.type.UserStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -60,5 +62,16 @@ public class MemberController {
     ) {
         memberService.badgeProcessed(badgeApplyId, process);
         return new ResponseEntity<>(ApiUtils.success(null, HttpStatus.OK), HttpStatus.OK);
+    }
+
+    @GetMapping("/list")
+    public ResponseEntity<ApiUtils.ApiResult<MemberListResp>> memberList(
+            @RequestParam(required = false) String nickName,
+            @RequestParam(required = false) Flag badge,
+            @RequestParam(required = false) UserStatus userStatus,
+            @PageableDefault(size = 20) Pageable pageable
+    ) {
+        MemberListResp response = memberService.getMemberList(nickName, badge, userStatus, pageable);
+        return new ResponseEntity<>(ApiUtils.success(response, HttpStatus.OK), HttpStatus.OK);
     }
 }

--- a/management/src/main/java/com/foodielog/management/member/controller/MemberController.java
+++ b/management/src/main/java/com/foodielog/management/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.foodielog.management.member.controller;
 
+import com.foodielog.management.member.dto.request.BlockReq;
 import com.foodielog.management.member.dto.response.BadgeApplyListResp;
 import com.foodielog.management.member.dto.response.MemberListResp;
 import com.foodielog.management.member.dto.response.WithdrawListResp;
@@ -17,6 +18,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
 import javax.validation.constraints.Positive;
 
 @RequiredArgsConstructor
@@ -73,5 +75,13 @@ public class MemberController {
     ) {
         MemberListResp response = memberService.getMemberList(nickName, badge, userStatus, pageable);
         return new ResponseEntity<>(ApiUtils.success(response, HttpStatus.OK), HttpStatus.OK);
+    }
+
+    @PostMapping("/block")
+    public ResponseEntity<ApiUtils.ApiResult<String>> block(
+            @RequestBody @Valid BlockReq request
+    ) {
+        memberService.blockProcessed(request);
+        return new ResponseEntity<>(ApiUtils.success(null, HttpStatus.CREATED), HttpStatus.CREATED);
     }
 }

--- a/management/src/main/java/com/foodielog/management/member/dto/request/BlockReq.java
+++ b/management/src/main/java/com/foodielog/management/member/dto/request/BlockReq.java
@@ -1,0 +1,20 @@
+package com.foodielog.management.member.dto.request;
+
+import lombok.Getter;
+import org.hibernate.validator.constraints.Length;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+
+@Getter
+public class BlockReq {
+
+    @NotNull(message = "값이 null 일 수 없습니다.")
+    @Positive(message = "양수만 가능합니다.")
+    private Long userId;
+
+    @Length(max = 100, message = "최대 100글자만 가능합니다.")
+    @NotBlank(message = "차단 사유를 작성해주세요.")
+    private String reason;
+}

--- a/management/src/main/java/com/foodielog/management/member/dto/response/MemberListResp.java
+++ b/management/src/main/java/com/foodielog/management/member/dto/response/MemberListResp.java
@@ -1,0 +1,43 @@
+package com.foodielog.management.member.dto.response;
+
+import com.foodielog.server.user.entity.User;
+import com.foodielog.server.user.type.Flag;
+import com.foodielog.server.user.type.UserStatus;
+import lombok.Getter;
+
+import java.sql.Timestamp;
+import java.util.List;
+
+@Getter
+public class MemberListResp {
+    private final List<memberDTO> content;
+
+    public MemberListResp(List<memberDTO> content) {
+        this.content = content;
+    }
+
+    @Getter
+    public static class memberDTO {
+        private final Long userId;
+        private final String nickName;
+        private final String email;
+        private final Flag flag;
+        private final Long feedCount;
+        private final Long replyCount;
+        private final Timestamp createdAt;
+        private final Long approveCount;
+        private final UserStatus userStatus;
+
+        public memberDTO(User user, Long feedCount, Long replyCount, Long approveCount) {
+            this.userId = user.getId();
+            this.nickName = user.getNickName();
+            this.email = user.getEmail();
+            this.flag = user.getBadgeFlag();
+            this.feedCount = feedCount;
+            this.replyCount = replyCount;
+            this.createdAt = user.getCreatedAt();
+            this.approveCount = approveCount;
+            this.userStatus = user.getStatus();
+        }
+    }
+}


### PR DESCRIPTION
## 요약
- 회원 목록 조회 구현
- 영구 차단 구현

## 작업 내용
- [x] 회원 목록 조회
- [x] 영구 차단

## 참고 사항
- ValidEnum nullable 기능 추가하여 default 는 false 인 상태로 null 값을 허용하게 하고 싶으면 true 로 바꾸어 사용 가능하도록 구현
    - param 값으로 받을 때 ValidEnum 은 null 을 허용하지 않아 구현함

## 관련 이슈
Close #133 
