### PR TITLE
[Feat] 신고 내역 검색 (#129)

### DIFF
--- a/core/src/main/java/com/foodielog/server/report/repository/ReportRepository.java
+++ b/core/src/main/java/com/foodielog/server/report/repository/ReportRepository.java
@@ -1,9 +1,11 @@
 package com.foodielog.server.report.repository;
 
 import com.foodielog.server.admin.type.ProcessedStatus;
+import com.foodielog.server.feed.type.ContentStatus;
 import com.foodielog.server.report.entity.Report;
 import com.foodielog.server.report.type.ReportType;
 import com.foodielog.server.user.entity.User;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -19,4 +21,17 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
     long countProcessedByStatus(@Param("reportedId") User reportedId, @Param("status") ProcessedStatus status);
 
     Optional<List<Report>> findAllByReportedIdAndContentId(User reportedId, Long contentId);
+
+    @Query(value = "SELECT r.* FROM report_tb r " +
+            "INNER JOIN (SELECT r2.content_id, MIN(r2.created_at) AS min_created_at " +
+            "FROM report_tb r2 " +
+            "LEFT JOIN user_tb reporter ON r2.reporter_id = reporter.id " +
+            "LEFT JOIN user_tb reported ON r2.reported_id = reported.id " +
+            "WHERE (:nickName IS NULL OR reporter.nick_name LIKE %:nickName% OR reported.nick_name LIKE %:nickName%) " +
+            "AND (:type IS NULL OR r2.type = :type) AND (:status IS NULL OR r2.status = :status) " +
+            "GROUP BY r2.content_id) AS grouped_reports " +
+            "ON r.content_id = grouped_reports.content_id " +
+            "ORDER BY grouped_reports.min_created_at, r.content_id, r.created_at", nativeQuery = true)
+    List<Report> findAllByParam(@Param("nickName") String nickName, @Param("type") ReportType type,
+                                @Param("status") ContentStatus status, Pageable pageable);
 }

--- a/management/src/main/java/com/foodielog/management/report/controller/ReportController.java
+++ b/management/src/main/java/com/foodielog/management/report/controller/ReportController.java
@@ -1,15 +1,19 @@
 package com.foodielog.management.report.controller;
 
 import com.foodielog.management.report.dto.request.ProcessReq;
+import com.foodielog.management.report.dto.response.ReportListResp;
 import com.foodielog.management.report.service.ReportService;
+import com.foodielog.server._core.customValid.valid.ValidEnum;
 import com.foodielog.server._core.util.ApiUtils;
+import com.foodielog.server.feed.type.ContentStatus;
+import com.foodielog.server.report.type.ReportType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RequestMapping("/admin/report")
@@ -23,5 +27,16 @@ public class ReportController {
     ) {
         reportService.process(request);
         return new ResponseEntity<>(ApiUtils.success(null, HttpStatus.OK), HttpStatus.OK);
+    }
+
+    @GetMapping("/list")
+    public ResponseEntity<ApiUtils.ApiResult<ReportListResp>> reportList(
+            @RequestParam(required = false) String nickName,
+            @RequestParam(required = false) @ValidEnum(enumClass = ReportType.class) ReportType type,
+            @RequestParam(required = false) @ValidEnum(enumClass = ContentStatus.class) ContentStatus status,
+            @PageableDefault(size = 10) Pageable pageable
+    ) {
+        ReportListResp response = reportService.getreportList(nickName, type, status, pageable);
+        return new ResponseEntity<>(ApiUtils.success(response, HttpStatus.OK), HttpStatus.OK);
     }
 }

--- a/management/src/main/java/com/foodielog/management/report/dto/response/ReportListResp.java
+++ b/management/src/main/java/com/foodielog/management/report/dto/response/ReportListResp.java
@@ -1,0 +1,94 @@
+package com.foodielog.management.report.dto.response;
+
+import com.foodielog.server.admin.type.ProcessedStatus;
+import com.foodielog.server.feed.entity.Feed;
+import com.foodielog.server.feed.entity.Media;
+import com.foodielog.server.reply.entity.Reply;
+import com.foodielog.server.report.entity.Report;
+import com.foodielog.server.report.type.ReportReason;
+import com.foodielog.server.report.type.ReportType;
+import lombok.Getter;
+
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class ReportListResp {
+    private final List<ReportDTO<?>> content;
+
+    public ReportListResp(List<ReportDTO<?>> content) {
+        this.content = content;
+    }
+
+    @Getter
+    public static class ReportDTO<T> {
+        private final Long reportId;
+        private final UserDTO reporter;
+        private final UserDTO reported;
+        private final ReportType type;
+        private final T detail;
+        private final ReportReason reason;
+        private final ProcessedStatus status;
+        private final Timestamp createdAt;
+        private final Timestamp updatedAt;
+
+        public ReportDTO(Report report, T detail) {
+            this.reportId = report.getId();
+            this.reporter = new UserDTO(report.getReporterId().getNickName(), report.getReporterId().getEmail());
+            this.reported = new UserDTO(report.getReportedId().getNickName(), report.getReportedId().getEmail());
+            this.type = report.getType();
+            this.detail = detail;
+            this.reason = report.getReportReason();
+            this.status = report.getStatus();
+            this.createdAt = report.getCreatedAt();
+            this.updatedAt = report.getUpdatedAt();
+        }
+    }
+
+    @Getter
+    private static class UserDTO {
+        private final String nickName;
+        private final String email;
+
+        private UserDTO(String nickName, String email) {
+            this.nickName = nickName;
+            this.email = email;
+        }
+    }
+
+    @Getter
+    public static class FeedDetail {
+        private final Long feedId;
+        private final List<FeedImageDTO> feedImages;
+        private final String content;
+
+        public FeedDetail(Feed feed, List<Media> mediaList) {
+            this.feedId = feed.getId();
+            this.feedImages = mediaList.stream()
+                    .map(FeedImageDTO::new)
+                    .collect(Collectors.toList());
+            this.content = feed.getContent();
+        }
+    }
+
+    @Getter
+    private static class FeedImageDTO {
+        private final String imageUrl;
+
+        private FeedImageDTO(Media media) {
+            this.imageUrl = media.getImageUrl();
+        }
+    }
+
+    @Getter
+    public static class ReplyDetail {
+        private final Long id;
+        private final String content;
+
+        public ReplyDetail(Reply reply) {
+            this.id = reply.getId();
+            this.content = reply.getContent();
+        }
+    }
+}

--- a/management/src/main/resources/data.sql
+++ b/management/src/main/resources/data.sql
@@ -75,8 +75,12 @@ VALUES (1, 'https://foodielog-bucket.s3.ap-northeast-2.amazonaws.com/55e8cfbc-59
         '2023-08-03');
 
 INSERT INTO report_tb (reporter_id, reported_id, type, content_id, report_reason, status, created_at, updated_at)
-VALUES (1, 2, 'FEED', 2, '광고', 'UNPROCESSED', '2023-08-10', '2023-08-10'),
-       (1, 2, 'REPLY', 6, '광고', 'UNPROCESSED', '2023-08-10', '2023-08-10');
+VALUES (1, 2, 'FEED', 2, 'ADVERTISEMENT', 'UNPROCESSED', '2023-08-10', '2023-08-10'),
+       (3, 2, 'FEED', 2, 'ADVERTISEMENT', 'UNPROCESSED', '2023-08-10', '2023-08-10'),
+       (2, 1, 'FEED', 1, 'SWEARING', 'APPROVED', '2023-08-11', '2023-08-11'),
+       (4, 2, 'FEED', 2, 'ADVERTISEMENT', 'UNPROCESSED', '2023-08-12', '2023-08-12'),
+       (5, 2, 'FEED', 2, 'ADVERTISEMENT', 'UNPROCESSED', '2023-08-12', '2023-08-12'),
+       (1, 2, 'REPLY', 6, 'ADVERTISEMENT', 'UNPROCESSED', '2023-08-12', '2023-08-12');
 
 INSERT INTO reply_tb (user_id, feed_id, content, status, created_at, updated_at)
 VALUES (1, 2, '너무 맛있어 보여요!', 'NORMAL', '2023-08-10', '2023-08-10'),


### PR DESCRIPTION
## 요약
신고 내역 검색 기능

## 작업 내용
- [ ] 검색 조건으로 필터링+그룹화+페이징

## 참고 사항
입력받은 파람을 조건으로 필터링하여 select
그런데
content_id가 같은 것끼리 연속으로 나오고(:그룹화),
각 그룹의 첫 데이터의 created_at을 기준으로 정렬하도록 쿼리 작성함

ex) 
아래와 같은 더미가 있을 때 
VALUES (1, 2, 'FEED', 2, 'ADVERTISEMENT', 'UNPROCESSED', '2023-08-10', '2023-08-10'),
       (3, 2, 'FEED', 2, 'ADVERTISEMENT', 'UNPROCESSED', '2023-08-10', '2023-08-10'),
       (2, 1, 'FEED', 1, 'SWEARING', 'APPROVED', '2023-08-11', '2023-08-11'),
       (4, 2, 'FEED', 2, 'ADVERTISEMENT', 'UNPROCESSED', '2023-08-12', '2023-08-12'),
       (5, 2, 'FEED', 2, 'ADVERTISEMENT', 'UNPROCESSED', '2023-08-12', '2023-08-12'),
       (1, 2, 'REPLY', 6, 'ADVERTISEMENT', 'UNPROCESSED', '2023-08-12', '2023-08-12');

다음 순서로 리턴됨
      (1, 2, 'FEED', 2, 'ADVERTISEMENT', 'UNPROCESSED', '2023-08-10', '2023-08-10'),
       (3, 2, 'FEED', 2, 'ADVERTISEMENT', 'UNPROCESSED', '2023-08-10', '2023-08-10'),
       (4, 2, 'FEED', 2, 'ADVERTISEMENT', 'UNPROCESSED', '2023-08-12', '2023-08-12'),
       (5, 2, 'FEED', 2, 'ADVERTISEMENT', 'UNPROCESSED', '2023-08-12', '2023-08-12'),
       (2, 1, 'FEED', 1, 'SWEARING', 'APPROVED', '2023-08-11', '2023-08-11'),
       (1, 2, 'REPLY', 6, 'ADVERTISEMENT', 'UNPROCESSED', '2023-08-12', '2023-08-12')

## 관련 이슈
Close #129
