### PR TITLE
[Fix] #149 auth 컨트롤러 앞에 prefix(api 또는 admin) 추가 

### DIFF
--- a/application/src/main/java/com/foodielog/application/user/controller/UserAuthController.java
+++ b/application/src/main/java/com/foodielog/application/user/controller/UserAuthController.java
@@ -26,7 +26,7 @@ import javax.validation.constraints.Size;
 
 @RequiredArgsConstructor
 @Validated
-@RequestMapping("/auth")
+@RequestMapping("/api/auth")
 @RestController
 public class UserAuthController {
     private final JwtTokenProvider jwtTokenProvider;

--- a/core/src/main/java/com/foodielog/server/_core/security/SecurityConfig.java
+++ b/core/src/main/java/com/foodielog/server/_core/security/SecurityConfig.java
@@ -74,7 +74,7 @@ public class SecurityConfig {
         http.authorizeRequests(
                 // '/api' 로 시작 하는 url 은 로그인 필요제
                 // @Todo "/h2-console/**" 접근은 개발 시에만 열어 두고 배포시 제거
-                authorize -> authorize.antMatchers("/auth/**", "/h2-console/**", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources/**").permitAll()    // 누구나 접근 가능
+                authorize -> authorize.antMatchers("/api/auth/**", "/admin/auth/**", "/h2-console/**", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources/**").permitAll()    // 누구나 접근 가능
                         .antMatchers("/api/**").hasAnyAuthority("USER", "ADMIN")
                         .antMatchers("/admin/**").hasAuthority("ADMIN")
                         .anyRequest().authenticated()

--- a/management/src/main/java/com/foodielog/management/user/controller/UserAuthController.java
+++ b/management/src/main/java/com/foodielog/management/user/controller/UserAuthController.java
@@ -20,7 +20,7 @@ import javax.validation.Valid;
 
 @RequiredArgsConstructor
 @Validated
-@RequestMapping("/auth")
+@RequestMapping("/admin/auth")
 @RestController
 public class UserAuthController {
     private final JwtTokenProvider jwtTokenProvider;


### PR DESCRIPTION
## 요약
auth 컨트롤러 앞에 prefix(api 또는 admin) 추가 

user 서버의 auth/** -> api/auth/**
admin 서버의 auth/** -> admin/auth/**

## 작업 내용
- [x] auth 컨트롤러 앞에 prefix(api 또는 admin) 추가 

## 참고 사항

## 관련 이슈
Close #149
