### PR TITLE
[Fix] #163 단일 피드 상세보기 토큰 없이 접속하도록 수정

### DIFF
--- a/application/src/main/java/com/foodielog/application/feed/controller/FeedController.java
+++ b/application/src/main/java/com/foodielog/application/feed/controller/FeedController.java
@@ -124,9 +124,9 @@ public class FeedController {
         return new ResponseEntity<>(ApiUtils.success(response, HttpStatus.OK), HttpStatus.OK);
     }
 
-    @GetMapping("/detail")
+    @GetMapping("/detail/{feedId}")
     public ResponseEntity<ApiUtils.ApiResult<FeedDetailResp>> detail(
-            @RequestParam @Positive Long feedId
+            @PathVariable Long feedId
     ) {
         FeedDetailResp response = feedService.getFeedDetail(feedId);
         return new ResponseEntity<>(ApiUtils.success(response, HttpStatus.OK), HttpStatus.OK);

--- a/core/src/main/java/com/foodielog/server/_core/security/SecurityConfig.java
+++ b/core/src/main/java/com/foodielog/server/_core/security/SecurityConfig.java
@@ -76,7 +76,7 @@ public class SecurityConfig {
         http.authorizeRequests(
                 // '/api' 로 시작 하는 url 은 로그인 필요제
                 // @Todo "/h2-console/**" 접근은 개발 시에만 열어 두고 배포시 제거
-                authorize -> authorize.antMatchers("/api/auth/**", "/admin/auth/**", "/h2-console/**", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources/**").permitAll()    // 누구나 접근 가능
+                authorize -> authorize.antMatchers("/api/auth/**", "/admin/auth/**", "/h2-console/**", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources/**", "/api/feed/detail/**").permitAll()    // 누구나 접근 가능
                         .antMatchers("/api/**").hasAnyAuthority("USER", "ADMIN")
                         .antMatchers("/admin/**").hasAuthority("ADMIN")
                         .anyRequest().authenticated()


### PR DESCRIPTION
## 요약
단일 피드 상세보기 토큰 없이 접속하도록 수정

## 작업 내용

- [x] 필터 접근 허용 url에 api/feed/detail/** 추가

## 참고 사항

## 관련 이슈
Close #163 
