### PR TITLE
[Fix] #185 메인 피드 및 유저 페이지 피드 최신순으로 정렬

### DIFF
--- a/application/src/main/java/com/foodielog/application/feed/controller/FeedController.java
+++ b/application/src/main/java/com/foodielog/application/feed/controller/FeedController.java
@@ -15,6 +15,7 @@ import com.foodielog.server.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -117,8 +118,8 @@ public class FeedController {
     @GetMapping("/list")
     public ResponseEntity<ApiUtils.ApiResult<MainFeedListResp>> list(
             @AuthenticationPrincipal PrincipalDetails principalDetails,
-            @RequestParam @PositiveOrZero Long feedId,
-            @PageableDefault(size = 15) Pageable pageable
+            @RequestParam(required = false) @Positive Long feedId,
+            @PageableDefault(size = 15, sort = "id", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         MainFeedListResp response = feedService.getMainFeed(principalDetails.getUser(), feedId, pageable);
         return new ResponseEntity<>(ApiUtils.success(response, HttpStatus.OK), HttpStatus.OK);

--- a/application/src/main/java/com/foodielog/application/user/controller/UserController.java
+++ b/application/src/main/java/com/foodielog/application/user/controller/UserController.java
@@ -7,6 +7,7 @@ import com.foodielog.server._core.util.ApiUtils;
 import com.foodielog.server.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,7 +16,6 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.constraints.Positive;
-import javax.validation.constraints.PositiveOrZero;
 
 @RequiredArgsConstructor
 @Validated
@@ -35,23 +35,13 @@ public class UserController {
         return new ResponseEntity<>(ApiUtils.success(response, HttpStatus.OK), HttpStatus.OK);
     }
 
-    @GetMapping("/{userId}/feed/thumbnail")
-    public ResponseEntity<ApiUtils.ApiResult<UserThumbnailResp>> getThumbnail(
+    @GetMapping("/{userId}/feed")
+    public ResponseEntity<ApiUtils.ApiResult<UserFeedResp>> getFeeds(
             @PathVariable Long userId,
-            @RequestParam @PositiveOrZero Long feedId,
-            @PageableDefault(size = 15) Pageable pageable
+            @RequestParam(required = false) @Positive Long feedId,
+            @PageableDefault(size = 15, sort = "id", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        UserThumbnailResp response = userService.getThumbnail(userId, feedId, pageable);
-        return new ResponseEntity<>(ApiUtils.success(response, HttpStatus.OK), HttpStatus.OK);
-    }
-
-    @GetMapping("/{userId}/feed/list")
-    public ResponseEntity<ApiUtils.ApiResult<UserFeedListResp>> getFeeds(
-            @PathVariable Long userId,
-            @RequestParam @PositiveOrZero Long feedId,
-            @PageableDefault(size = 15) Pageable pageable
-    ) {
-        UserFeedListResp response = userService.getFeeds(userId, feedId, pageable);
+        UserFeedResp response = userService.getFeeds(userId, feedId, pageable);
         return new ResponseEntity<>(ApiUtils.success(response, HttpStatus.OK), HttpStatus.OK);
     }
 

--- a/application/src/main/java/com/foodielog/application/user/dto/response/UserFeedResp.java
+++ b/application/src/main/java/com/foodielog/application/user/dto/response/UserFeedResp.java
@@ -9,10 +9,10 @@ import java.sql.Timestamp;
 import java.util.List;
 
 @Getter
-public class UserFeedListResp {
+public class UserFeedResp {
     private final List<UserFeedsDTO> content;
 
-    public UserFeedListResp(List<UserFeedsDTO> content) {
+    public UserFeedResp(List<UserFeedsDTO> content) {
         this.content = content;
     }
 
@@ -37,6 +37,7 @@ public class UserFeedListResp {
         private final String nickName;
         private final String profileImageUrl;
         private final Long feedId;
+        private final String thumbnailUrl;
         private final Timestamp createdAt;
         private final Timestamp updatedAt;
         private final List<FeedImageDTO> feedImages;
@@ -49,6 +50,7 @@ public class UserFeedListResp {
             this.nickName = feed.getUser().getNickName();
             this.profileImageUrl = feed.getUser().getProfileImageUrl();
             this.feedId = feed.getId();
+            this.thumbnailUrl = feed.getThumbnailUrl();
             this.createdAt = feed.getCreatedAt();
             this.updatedAt = feed.getUpdatedAt();
             this.feedImages = feedImages;

--- a/application/src/main/java/com/foodielog/application/user/service/UserService.java
+++ b/application/src/main/java/com/foodielog/application/user/service/UserService.java
@@ -1,7 +1,10 @@
 package com.foodielog.application.user.service;
 
 import com.foodielog.application._core.fcm.FcmMessageProvider;
-import com.foodielog.application.user.dto.response.*;
+import com.foodielog.application.user.dto.response.UserFeedResp;
+import com.foodielog.application.user.dto.response.UserProfileResp;
+import com.foodielog.application.user.dto.response.UserRestaurantListResp;
+import com.foodielog.application.user.dto.response.UserSearchResp;
 import com.foodielog.server._core.error.exception.Exception404;
 import com.foodielog.server.feed.entity.Feed;
 import com.foodielog.server.feed.entity.Media;
@@ -60,40 +63,27 @@ public class UserService {
     }
 
     @Transactional(readOnly = true)
-    public UserThumbnailResp getThumbnail(Long userId, Long feedId, Pageable pageable) {
+    public UserFeedResp getFeeds(Long userId, Long feedId, Pageable pageable) {
         User user = validationUserId(userId);
 
         List<Feed> feeds = feedRepository.getFeeds(user, feedId, ContentStatus.NORMAL, pageable);
 
-        List<UserThumbnailResp.ThumbnailDTO> thumbnailDTO = feeds.stream()
-                .map(UserThumbnailResp.ThumbnailDTO::new)
-                .collect(Collectors.toList());
-
-        return new UserThumbnailResp(thumbnailDTO);
-    }
-
-    @Transactional(readOnly = true)
-    public UserFeedListResp getFeeds(Long userId, Long feedId, Pageable pageable) {
-        User user = validationUserId(userId);
-
-        List<Feed> feeds = feedRepository.getFeeds(user, feedId, ContentStatus.NORMAL, pageable);
-
-        List<UserFeedListResp.UserFeedsDTO> userFeedsDTOList = new ArrayList<>();
+        List<UserFeedResp.UserFeedsDTO> userFeedsDTOList = new ArrayList<>();
 
         for (Feed feed : feeds) {
             List<Media> mediaList = mediaRepository.findByFeed(feed);
 
-            List<UserFeedListResp.FeedImageDTO> feedImages = getFeedImageDTO(mediaList);
-            UserFeedListResp.FeedDTO feedDTO = getFeedDTO(feed, feedImages);
-            UserFeedListResp.UserRestaurantDTO userRestaurantDTO = getUserRestaurantDTO(feed);
+            List<UserFeedResp.FeedImageDTO> feedImages = getFeedImageDTO(mediaList);
+            UserFeedResp.FeedDTO feedDTO = getFeedDTO(feed, feedImages);
+            UserFeedResp.UserRestaurantDTO userRestaurantDTO = getUserRestaurantDTO(feed);
 
             boolean isFollowed = followRepository.existsByFollowingIdAndFollowedId(user, feed.getUser());
             boolean isLiked = feedLikeRepository.existsByUserAndFeed(user, feed);
 
-            userFeedsDTOList.add(new UserFeedListResp.UserFeedsDTO(feedDTO, userRestaurantDTO, isFollowed, isLiked));
+            userFeedsDTOList.add(new UserFeedResp.UserFeedsDTO(feedDTO, userRestaurantDTO, isFollowed, isLiked));
         }
 
-        return new UserFeedListResp(userFeedsDTOList);
+        return new UserFeedResp(userFeedsDTOList);
     }
 
     @Transactional(readOnly = true)
@@ -121,21 +111,21 @@ public class UserService {
         return new UserRestaurantListResp(restaurantListDTOList);
     }
 
-    private UserFeedListResp.UserRestaurantDTO getUserRestaurantDTO(Feed feed) {
+    private UserFeedResp.UserRestaurantDTO getUserRestaurantDTO(Feed feed) {
         Restaurant restaurant = feed.getRestaurant();
-        return new UserFeedListResp.UserRestaurantDTO(restaurant);
+        return new UserFeedResp.UserRestaurantDTO(restaurant);
     }
 
-    private UserFeedListResp.FeedDTO getFeedDTO(Feed feed, List<UserFeedListResp.FeedImageDTO> feedImages) {
+    private UserFeedResp.FeedDTO getFeedDTO(Feed feed, List<UserFeedResp.FeedImageDTO> feedImages) {
         Long likeCount = feedLikeRepository.countByFeed(feed);
         Long replyCount = replyRepository.countByFeedAndStatus(feed, ContentStatus.NORMAL);
 
-        return new UserFeedListResp.FeedDTO(feed, feedImages, likeCount, replyCount);
+        return new UserFeedResp.FeedDTO(feed, feedImages, likeCount, replyCount);
     }
 
-    private List<UserFeedListResp.FeedImageDTO> getFeedImageDTO(List<Media> mediaList) {
+    private List<UserFeedResp.FeedImageDTO> getFeedImageDTO(List<Media> mediaList) {
         return mediaList.stream()
-                .map(UserFeedListResp.FeedImageDTO::new)
+                .map(UserFeedResp.FeedImageDTO::new)
                 .collect(Collectors.toList());
     }
 

--- a/core/src/main/java/com/foodielog/server/feed/repository/FeedRepository.java
+++ b/core/src/main/java/com/foodielog/server/feed/repository/FeedRepository.java
@@ -18,7 +18,7 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
     List<Feed> findByUserIdAndStatus(Long userId, ContentStatus status);
 
     @Query("SELECT f FROM Feed f " +
-            "WHERE f.user = :user AND f.id > :feedId AND f.status = :status")
+            "WHERE f.user = :user AND (:feedId IS NULL OR f.id < :feedId) AND f.status = :status")
     List<Feed> getFeeds(@Param("user") User user, @Param("feedId") Long feedId, @Param("status") ContentStatus status, Pageable pageable);
 
     List<Feed> findAllByRestaurantIdAndStatus(Long restaurantId, ContentStatus status);
@@ -37,7 +37,7 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
     @Query("SELECT f FROM Feed f " +
             "LEFT JOIN Follow fo ON f.user = fo.followedId AND fo.followingId = :user " +
             "WHERE (fo.followedId IS NOT NULL " +
-            "OR f.id IN (SELECT li.feed FROM FeedLike li WHERE li.feed.id > :feedId GROUP BY li.feed HAVING COUNT(li.feed) >= :likeCount)) " +
+            "OR f.id IN (SELECT li.feed FROM FeedLike li WHERE (:feedId IS NULL OR li.feed.id < :feedId) GROUP BY li.feed HAVING COUNT(li.feed) >= :likeCount)) " +
             "AND f.status = 'NORMAL' AND f.createdAt >= :date AND f.user != :user")
     List<Feed> getMainFeed(@Param("user") User user, @Param("feedId") Long feedId,
                            @Param("likeCount") Long likeCount, @Param("date") Timestamp date, Pageable pageable);


### PR DESCRIPTION
## 요약
- 메인 피드가 최신순으로 나오도록 수정
- 유저 페이지에서 썸네일, 피드 리스트 최신순으로 나오도록 수정
- 유저 페이지 썸네일, 피드 리스트 api 합침

## 작업 내용
- [x] 메인 피드가 최신순으로 나오도록 수정
- [x] 유저 페이지에서 썸네일, 피드 리스트 최신순으로 나오도록 수정
- [x] 유저 페이지 썸네일, 피드 리스트 api 합침

## 참고 사항
- 메인 피드 및 유저 페이지에서 피드 리스트를 처음 받을 때 feedId 를 아무 값을 주지 않아도 되도록 수정
- 기존 썸네일 및 피드 리스트를  /api/user/{userId}/feed 로 변경

## 관련 이슈
Close #185 
