### PR TITLE
[Feat] #187  카카오 중복 체크 api 

### DIFF
--- a/application/src/main/java/com/foodielog/application/user/controller/UserAuthController.java
+++ b/application/src/main/java/com/foodielog/application/user/controller/UserAuthController.java
@@ -31,7 +31,7 @@ import javax.validation.constraints.Size;
 public class UserAuthController {
     private final JwtTokenProvider jwtTokenProvider;
     private final UserAuthService userAuthService;
-    private final UserOauthService oauthUserService;
+    private final UserOauthService userOauthService;
 
     @RequestMapping("/healthcheck")
     public ResponseEntity<ApiUtils.ApiResult<Object>> healthcheck() {
@@ -50,7 +50,7 @@ public class UserAuthController {
         return new ResponseEntity<>(ApiUtils.success(response, HttpStatus.CREATED), headers, HttpStatus.CREATED);
     }
 
-    /* 회원 가입 */
+    /* 중복 체크 */
     @GetMapping("/exists/email")
     public ResponseEntity<ApiUtils.ApiResult<ExistsEmailResp>> checkExistsEmail(
             @RequestParam @Email String input
@@ -60,6 +60,16 @@ public class UserAuthController {
         return new ResponseEntity<>(ApiUtils.success(response, httpStatus), httpStatus);
     }
 
+    @GetMapping("/exists/kakao")
+    public ResponseEntity<ApiUtils.ApiResult<ExistsKakaoResp>> checkExistsKakao(
+            @RequestParam String token
+    ) {
+        ExistsKakaoResp response = userOauthService.checkExistsKakao(token);
+        HttpStatus httpStatus = response.getIsExists() ? HttpStatus.CONFLICT : HttpStatus.OK;
+        return new ResponseEntity<>(ApiUtils.success(response, httpStatus), httpStatus);
+    }
+
+    /* 회원 가입 */
     @PostMapping("/signup")
     public ResponseEntity<ApiUtils.ApiResult<SignUpResp>> signUp(
             @RequestPart(value = "content") @Valid SignUpReq request,
@@ -112,7 +122,7 @@ public class UserAuthController {
     public ResponseEntity<ApiUtils.ApiResult<KakaoLoginResp>> kakaoLogin(
             @RequestParam String token
     ) {
-        KakaoLoginResp response = oauthUserService.kakaoLogin(token);
+        KakaoLoginResp response = userOauthService.kakaoLogin(token);
         HttpHeaders headers = getCookieHeaders(response.getRefreshToken());
         return new ResponseEntity<>(ApiUtils.success(response, HttpStatus.OK), headers, HttpStatus.OK);
     }

--- a/application/src/main/java/com/foodielog/application/user/dto/response/ExistsKakaoResp.java
+++ b/application/src/main/java/com/foodielog/application/user/dto/response/ExistsKakaoResp.java
@@ -1,0 +1,14 @@
+package com.foodielog.application.user.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class ExistsKakaoResp {
+    private final String kakaoAccessToken;
+    private final Boolean isExists;
+
+    public ExistsKakaoResp(String kakaoAccessToken, Boolean isExists) {
+        this.kakaoAccessToken = kakaoAccessToken;
+        this.isExists = isExists;
+    }
+}

--- a/application/src/main/java/com/foodielog/application/user/service/UserOauthService.java
+++ b/application/src/main/java/com/foodielog/application/user/service/UserOauthService.java
@@ -1,5 +1,6 @@
 package com.foodielog.application.user.service;
 
+import com.foodielog.application.user.dto.response.ExistsKakaoResp;
 import com.foodielog.application.user.dto.response.KakaoLoginResp;
 import com.foodielog.server._core.error.ErrorMessage;
 import com.foodielog.server._core.error.exception.Exception400;
@@ -20,8 +21,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import javax.transaction.Transactional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -36,6 +37,15 @@ public class UserOauthService {
     private final RedisService redisService;
     private final JsonConverter jsonConverter;
     private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public ExistsKakaoResp checkExistsKakao(String token) {
+        KakaoLoginResp.kakaoApiResp.UserInfo kakaoUserInfo = getKakaoUserInfo(token);
+        KakaoLoginResp.kakaoApiResp.KakaoAccount kakaoAccount = kakaoUserInfo.getKakaoAccount();
+
+        Boolean isExists = userRepository.existsByEmail(kakaoAccount.getEmail());
+        return new ExistsKakaoResp(token, isExists);
+    }
 
     @Transactional
     public KakaoLoginResp kakaoLogin(String token) {


### PR DESCRIPTION
## 요약
카카오 로그인 버튼 클릭 시 최초 연결인 경우에만 약관동의& 프로필 수정화면이 보여야함
때문에 최초 연결인지 확인할 수 있도록 이메일 중복체크 api 추가

## 작업 내용
- [x]  카카오 이메일 중복체크 api

## 참고 사항

## 관련 이슈
Close #187
