### PR TITLE
refactor: 카카오 중복체크 응답 상태코드 변경 (#189)

### DIFF
--- a/application/src/main/java/com/foodielog/application/user/controller/UserAuthController.java
+++ b/application/src/main/java/com/foodielog/application/user/controller/UserAuthController.java
@@ -65,8 +65,7 @@ public class UserAuthController {
             @RequestParam String token
     ) {
         ExistsKakaoResp response = userOauthService.checkExistsKakao(token);
-        HttpStatus httpStatus = response.getIsExists() ? HttpStatus.CONFLICT : HttpStatus.OK;
-        return new ResponseEntity<>(ApiUtils.success(response, httpStatus), httpStatus);
+        return new ResponseEntity<>(ApiUtils.success(response, HttpStatus.OK), HttpStatus.OK);
     }
 
     /* 회원 가입 */


### PR DESCRIPTION
## 요약
기본 이메일 체크와 동일하게 중복일 때 409를 보내도록 되어있는데
409인 경우 응답바디를 받을 수 없음
-> 중복 여부와 관계없이 코드 200으로 응답

## 작업 내용
- [x]  상태코드 200으로 통일

## 참고 사항

## 관련 이슈
Close #189
