### PR TITLE
[Fix] #209 차단 및 탈퇴 유저 팔로우에서 제외

### DIFF
--- a/core/src/main/java/com/foodielog/server/user/repository/FollowRepository.java
+++ b/core/src/main/java/com/foodielog/server/user/repository/FollowRepository.java
@@ -3,20 +3,37 @@ package com.foodielog.server.user.repository;
 import com.foodielog.server.user.entity.Follow;
 import com.foodielog.server.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface FollowRepository extends JpaRepository<Follow, Long> {
+    @Query("SELECT COUNT(f) " +
+            "FROM Follow f " +
+            "LEFT JOIN User u ON f.followingId = u " +
+            "WHERE f.followedId = :followedId AND u.status = 'NORMAL'")
     Long countByFollowedId(User followedId);
 
+    @Query("SELECT COUNT(f) " +
+            "FROM Follow f " +
+            "LEFT JOIN User u ON f.followedId = u " +
+            "WHERE f.followingId = :followingId AND u.status = 'NORMAL'")
     Long countByFollowingId(User followingId);
 
     Optional<Follow> findByFollowingIdAndFollowedId(User following, User followed);
 
     boolean existsByFollowingIdAndFollowedId(User following, User followed);
 
+    @Query("SELECT f " +
+            "FROM Follow f " +
+            "LEFT JOIN User u ON f.followingId = u " +
+            "WHERE f.followedId = :owner AND u.status = 'NORMAL'")
     List<Follow> findByFollowedId(User owner);
 
+    @Query("SELECT f " +
+            "FROM Follow f " +
+            "LEFT JOIN User u ON f.followedId = u " +
+            "WHERE f.followingId = :owner AND u.status = 'NORMAL'")
     List<Follow> findByFollowingId(User owner);
 }


### PR DESCRIPTION
## 요약
- 차단 및 탈퇴 유저 팔로우에서 제외

## 작업 내용
- [x] 차단 및 탈퇴 유저 팔로우에서 제외

## 참고 사항
```java
    Optional<Follow> findByFollowingIdAndFollowedId(User following, User followed);

    boolean existsByFollowingIdAndFollowedId(User following, User followed);
```
- 해당 쿼리에서는 Join 을 적용 시키지 않았습니다.
   - `findByFollowingIdAndFollowedId` 는 팔로우 생성 및 언팔로우 시에 사용이 되어 이미 차단 및 탈퇴에 대한 유저는 전 단계에서 user 가 있는지 확인하기 때문에 제외 했습니다.
   - `existsByFollowingIdAndFollowedId` 는 많은 곳에 사용이 되었는데 주로 피드에서 많이 사용되는 것으로 확인했습니다. 마찬가지로 피드는 차단 및 탈퇴 시에 피드 데이터가 삭제 처리로 되기 때문에 차단 및 탈퇴 된 유저로 인한 버그가 발생하지 않는다고 판단하여 제외 시켰습니다.

## 관련 이슈
Close #209 
