### PR TITLE
[Fix] #211 관리자 뱃지 신청 목록 수정

### DIFF
--- a/core/src/main/java/com/foodielog/server/admin/repository/BadgeApplyRepository.java
+++ b/core/src/main/java/com/foodielog/server/admin/repository/BadgeApplyRepository.java
@@ -16,7 +16,8 @@ public interface BadgeApplyRepository extends JpaRepository<BadgeApply, Long> {
 
     @Query("SELECT b FROM BadgeApply b " +
             "WHERE (:nickName IS NULL OR b.user.nickName LIKE %:nickName%) " +
-            "AND (:status IS NULL OR b.status = :status) ")
+            "AND (:status IS NULL OR b.status = :status) " +
+            "AND b.user.status = 'NORMAL'")
     List<BadgeApply> findByStatus(Pageable pageable, @Param("nickName") String nickName, @Param("status") ProcessedStatus status);
 
     Optional<BadgeApply> findByIdAndStatus(Long badgeApplyId, ProcessedStatus processedStatus);

--- a/management/src/main/java/com/foodielog/management/member/controller/MemberController.java
+++ b/management/src/main/java/com/foodielog/management/member/controller/MemberController.java
@@ -32,7 +32,7 @@ public class MemberController {
     @GetMapping("/withdraw/list")
     public ResponseEntity<ApiUtils.ApiResult<WithdrawListResp>> withdrawMemberList(
             @RequestParam(required = false) String nickName,
-            @RequestParam(required = false) @ValidEnum(enumClass = Flag.class) Flag badge,
+            @RequestParam(required = false) @ValidEnum(enumClass = Flag.class, nullable = true) Flag badge,
             @PageableDefault(size = 20) Pageable pageable
     ) {
         WithdrawListResp response = memberService.getWithdrawList(nickName, badge, pageable);
@@ -50,7 +50,7 @@ public class MemberController {
     @GetMapping("/badge/list")
     public ResponseEntity<ApiUtils.ApiResult<BadgeApplyListResp>> badgeApplyList(
             @RequestParam(required = false) String nickName,
-            @RequestParam(required = false) @ValidEnum(enumClass = ProcessedStatus.class) ProcessedStatus processedStatus,
+            @RequestParam(required = false) @ValidEnum(enumClass = ProcessedStatus.class, nullable = true) ProcessedStatus processedStatus,
             @PageableDefault(size = 20) Pageable pageable
     ) {
         BadgeApplyListResp response = memberService.getBadgeApplyList(nickName, processedStatus, pageable);

--- a/management/src/main/java/com/foodielog/management/report/controller/ReportController.java
+++ b/management/src/main/java/com/foodielog/management/report/controller/ReportController.java
@@ -32,8 +32,8 @@ public class ReportController {
     @GetMapping("/list")
     public ResponseEntity<ApiUtils.ApiResult<ReportListResp>> reportList(
             @RequestParam(required = false) String nickName,
-            @RequestParam(required = false) @ValidEnum(enumClass = ReportType.class) ReportType type,
-            @RequestParam(required = false) @ValidEnum(enumClass = ContentStatus.class) ContentStatus status,
+            @RequestParam(required = false) @ValidEnum(enumClass = ReportType.class, nullable = true) ReportType type,
+            @RequestParam(required = false) @ValidEnum(enumClass = ContentStatus.class, nullable = true) ContentStatus status,
             @PageableDefault(size = 10) Pageable pageable
     ) {
         ReportListResp response = reportService.getReportList(nickName, type, status, pageable);

--- a/management/src/main/java/com/foodielog/management/report/controller/ReportController.java
+++ b/management/src/main/java/com/foodielog/management/report/controller/ReportController.java
@@ -12,12 +12,13 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
+@Validated
 @RequestMapping("/admin/report")
-@Controller
+@RestController
 public class ReportController {
     private final ReportService reportService;
 


### PR DESCRIPTION
## 요약
관리자 뱃지 신청 목록, 탈퇴 회원  목록 조회 시 parma이 없어도 조회 가능하도록 수정

## 작업 내용

- [x] nullable = true 추가
- [x] 목록 조회 시 차단 및 탈퇴 유저는 제외 하도록 수정

## 참고 사항

## 관련 이슈
Close #211 
