### PR TITLE
[Fix] #217 cookie domain 설정

### DIFF
--- a/core/src/main/java/com/foodielog/server/_core/util/CookieUtil.java
+++ b/core/src/main/java/com/foodielog/server/_core/util/CookieUtil.java
@@ -9,6 +9,7 @@ public class CookieUtil {
     public static ResponseCookie getRefreshTokenCookie(String refreshToken) {
         return ResponseCookie.from(NAME_REFRESH_TOKEN, refreshToken)
                 .maxAge(JwtTokenProvider.EXP_REFRESH)
+                .domain("https://www.foodielog.shop")
                 .path("/")
                 .secure(true) // https 환경에서만 쿠키가 발동
                 .sameSite("None") // 크로스 사이트에도 전송 가능


### PR DESCRIPTION
## 요약
클라이언트에서 refreshToken 쿠키를 document.cookie로 접근할 수 없음
토큰 재발급 로직 구현을 위해 쿠키에 접근해야함 
쿠키의 도메인을 클라이언트 주소로 설정하지 않아 발생한 것으로 예상됨

## 작업 내용
- [x] cookie domain 설정

## 참고 사항

## 관련 이슈
Close #217
