### PR TITLE
[Setting] Jacoco Setting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,10 +14,46 @@ subprojects {
     apply plugin: 'java'
     apply plugin: 'org.springframework.boot'
     apply plugin: 'io.spring.dependency-management'
+    apply plugin: 'jacoco'
 
     group = 'com.foodie-log'
     version = '0.0.1-SNAPSHOT'
     sourceCompatibility = '11'
+
+    jacoco {
+        toolVersion = "0.8.9"
+    }
+
+    test {
+        useJUnitPlatform()
+        finalizedBy 'jacocoTestReport'
+    }
+
+    jacocoTestReport {
+        dependsOn test
+        reports {
+            html.required = true
+
+        }
+
+        finalizedBy 'jacocoTestCoverageVerification'
+    }
+
+    jacocoTestCoverageVerification {
+        violationRules {
+
+            rule {
+                enabled = true
+                element = 'CLASS'
+
+                limit {
+                    counter = 'LINE'
+                    value = 'COVEREDRATIO'
+                    minimum = 0.00
+                }
+            }
+        }
+    }
 
     configurations {
         compileOnly {
@@ -46,9 +82,6 @@ subprojects {
         implementation 'com.google.firebase:firebase-admin:9.1.1'
     }
 
-    tasks.named('test') {
-        useJUnitPlatform()
-    }
 }
 
 project(':core') {


### PR DESCRIPTION
## 요약
- CI 활용성 및 테스트 커버리지 측정을 위한 Jacoco 설정

## 작업 내용
```java
    jacocoTestCoverageVerification {
        violationRules {

            rule {
                enabled = true
                element = 'CLASS'

                limit {
                    counter = 'LINE'
                    value = 'COVEREDRATIO'
                    minimum = 0.00
                }
            }
        }
    }
```
- 테스트 검증을 위한 부분으로 `minimum` 수치를 통해서 빌드가 실패하도록 설정이 가능하나 현재 배포중인 상태라서 `0.00` 으로 설정

```bash
   ├─build
   │  ├─reports
   │  │  ├─html
``` 
- 패키지 위치에서 `index.html` 을 통해 테스트 커버리지를 확인할 수 있습니다.

## 참고 사항
- [Jacoco Counter Line vs Instruction](https://bottom-to-top.tistory.com/37)
<br/>
<div align="center">
            <img src="https://github.com/FoodieLog/foodie-log-server/assets/84082544/4ef1401e-aaf6-462a-a9d7-265fb63f6f92">
</div>

## 관련 이슈
Close #223 
