### PR TITLE
[Fix] #235 메인 피드 API 오류 수정

### DIFF
--- a/core/src/main/java/com/foodielog/server/feed/repository/FeedRepository.java
+++ b/core/src/main/java/com/foodielog/server/feed/repository/FeedRepository.java
@@ -37,7 +37,7 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
     @Query("SELECT f FROM Feed f " +
             "LEFT JOIN Follow fo ON f.user = fo.followedId AND fo.followingId = :user " +
             "WHERE (fo.followedId IS NOT NULL " +
-            "OR f.id IN (SELECT li.feed FROM FeedLike li GROUP BY li.feed HAVING COUNT(li.feed) >= :likeCount)) " +
+            "OR f.id IN ((SELECT f2.id FROM Feed f2 LEFT JOIN FeedLike li ON f2 = li.feed GROUP BY f2 HAVING COUNT(f2) >= :likeCount))) " +
             "AND f.status = 'NORMAL' AND f.createdAt >= :date AND f.user != :user AND (:feedId IS NULL OR f.id < :feedId)")
     List<Feed> getMainFeed(@Param("user") User user, @Param("feedId") Long feedId,
                            @Param("likeCount") Long likeCount, @Param("date") Timestamp date, Pageable pageable);


### PR DESCRIPTION
## 요약
- 메인 피드 API 오류 수정

## 작업 내용
```java
@Query("SELECT f FROM Feed f " +
            "LEFT JOIN Follow fo ON f.user = fo.followedId AND fo.followingId = :user " +
            "WHERE (fo.followedId IS NOT NULL " +
            "OR f.id IN (SELECT li.feed FROM FeedLike li GROUP BY li.feed HAVING COUNT(li.feed) >= :likeCount)) " +
            "AND f.status = 'NORMAL' AND f.createdAt >= :date AND f.user != :user AND (:feedId IS NULL OR f.id < :feedId)")
```
- FeedLike 는 좋아요를 눌러야 생기는 테이블이기에 의도 했던 내용과 달라 수정했습니다.

```java
@Query("SELECT f FROM Feed f " +
            "LEFT JOIN Follow fo ON f.user = fo.followedId AND fo.followingId = :user " +
            "WHERE (fo.followedId IS NOT NULL " +
            "OR f.id IN ((SELECT f2.id FROM Feed f2 LEFT JOIN FeedLike li ON f2 = li.feed GROUP BY f2 HAVING COUNT(f2) >= :likeCount))) " +
            "AND f.status = 'NORMAL' AND f.createdAt >= :date AND f.user != :user AND (:feedId IS NULL OR f.id < :feedId)")
```
- 서브 쿼리문에서 LEFT JOIN 을 사용하여 좋아요를 COUNT 하도록 수정하였습니다.

## 참고 사항

## 관련 이슈
Close #235 
