### PR TITLE
[Feat] #248 멘션 기능 추가

### DIFF
--- a/application/src/main/java/com/foodielog/application/mention/service/MentionModuleService.java
+++ b/application/src/main/java/com/foodielog/application/mention/service/MentionModuleService.java
@@ -1,0 +1,17 @@
+package com.foodielog.application.mention.service;
+
+import com.foodielog.server.mention.entity.Mention;
+import com.foodielog.server.mention.repository.MentionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class MentionModuleService {
+    private final MentionRepository mentionRepository;
+
+    public Mention save(Mention mention) {
+        return mentionRepository.save(mention);
+    }
+
+}

--- a/application/src/main/java/com/foodielog/application/mention/service/MentionModuleService.java
+++ b/application/src/main/java/com/foodielog/application/mention/service/MentionModuleService.java
@@ -2,8 +2,11 @@ package com.foodielog.application.mention.service;
 
 import com.foodielog.server.mention.entity.Mention;
 import com.foodielog.server.mention.repository.MentionRepository;
+import com.foodielog.server.reply.entity.Reply;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @Service
@@ -14,4 +17,7 @@ public class MentionModuleService {
         return mentionRepository.save(mention);
     }
 
+    public List<Mention> getAll(Reply reply) {
+        return mentionRepository.findByReply(reply);
+    }
 }

--- a/application/src/main/java/com/foodielog/application/reply/dto/ReplyCreateParam.java
+++ b/application/src/main/java/com/foodielog/application/reply/dto/ReplyCreateParam.java
@@ -4,6 +4,8 @@ import com.foodielog.server.user.entity.User;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.List;
+
 @Builder
 @Getter
 public class ReplyCreateParam {
@@ -15,4 +17,6 @@ public class ReplyCreateParam {
     private String content;
 
     private Long parentId;
+
+    private List<Long> mentionedIds;
 }

--- a/application/src/main/java/com/foodielog/application/reply/dto/ReplyCreateReq.java
+++ b/application/src/main/java/com/foodielog/application/reply/dto/ReplyCreateReq.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Positive;
 import javax.validation.constraints.Size;
+import java.util.List;
 
 @Getter
 public class ReplyCreateReq {
@@ -17,12 +18,15 @@ public class ReplyCreateReq {
     @Positive
     private Long parentId;
 
+    private List<Long> mentionedIds;
+
     public ReplyCreateParam toParamWith(User user, Long feedId) {
         return ReplyCreateParam.builder()
                 .user(user)
                 .feedId(feedId)
                 .content(content)
                 .parentId(parentId)
+                .mentionedIds(mentionedIds)
                 .build();
     }
 }

--- a/application/src/main/java/com/foodielog/application/reply/service/dto/ReplyListResp.java
+++ b/application/src/main/java/com/foodielog/application/reply/service/dto/ReplyListResp.java
@@ -34,13 +34,13 @@ public class ReplyListResp {
         private final Timestamp createdAt;
         private final List<ReplyDTO> replyList;
 
-        public ListDTO(Feed feed, List<ReplyDTO> replyListDTO) {
+        public ListDTO(Feed feed, List<ReplyDTO> replyDTOList) {
             this.userId = feed.getUser().getId();
             this.nickName = feed.getUser().getNickName();
             this.profileImageUrl = feed.getUser().getProfileImageUrl();
             this.content = feed.getContent();
             this.createdAt = feed.getCreatedAt();
-            this.replyList = replyListDTO;
+            this.replyList = replyDTOList;
         }
     }
 
@@ -54,8 +54,9 @@ public class ReplyListResp {
         private final String content;
         private final Timestamp createdAt;
         private final List<ReplyDTO> childList;
+        private final List<MentionDTO> mentionList;
 
-        public ReplyDTO(Reply reply, List<ReplyDTO> childList) {
+        public ReplyDTO(Reply reply, List<ReplyDTO> childList, List<MentionDTO> mentionList) {
             this.id = reply.getId();
             this.userId = reply.getUser().getId();
             this.nickName = reply.getUser().getNickName();
@@ -63,6 +64,18 @@ public class ReplyListResp {
             this.content = reply.getContent();
             this.createdAt = reply.getCreatedAt();
             this.childList = childList;
+            this.mentionList = mentionList;
+        }
+    }
+
+    @Getter
+    public static class MentionDTO {
+        private final Long userId;
+        private final String nickName;
+
+        public MentionDTO(Long userId, String nickName) {
+            this.userId = userId;
+            this.nickName = nickName;
         }
     }
 }

--- a/core/src/main/java/com/foodielog/server/mention/entity/Mention.java
+++ b/core/src/main/java/com/foodielog/server/mention/entity/Mention.java
@@ -1,0 +1,45 @@
+package com.foodielog.server.mention.entity;
+
+import com.foodielog.server.reply.entity.Reply;
+import com.foodielog.server.user.entity.User;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import javax.persistence.*;
+import java.sql.Timestamp;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@DynamicInsert
+@Table(name = "mention_tb")
+@Entity
+public class Mention {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reply_id")
+    private Reply reply;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mentioned_id")
+    private User mentionedUser;
+
+    @CreationTimestamp
+    private Timestamp createdAt;
+
+    @UpdateTimestamp
+    private Timestamp updatedAt;
+
+    public Mention createMention(Reply reply, User mentionedUser) {
+        Mention mention = new Mention();
+        mention.reply = reply;
+        mention.mentionedUser = mentionedUser;
+        return mention;
+    }
+}

--- a/core/src/main/java/com/foodielog/server/mention/entity/Mention.java
+++ b/core/src/main/java/com/foodielog/server/mention/entity/Mention.java
@@ -36,7 +36,7 @@ public class Mention {
     @UpdateTimestamp
     private Timestamp updatedAt;
 
-    public Mention createMention(Reply reply, User mentionedUser) {
+    public static Mention createMention(Reply reply, User mentionedUser) {
         Mention mention = new Mention();
         mention.reply = reply;
         mention.mentionedUser = mentionedUser;

--- a/core/src/main/java/com/foodielog/server/mention/repository/MentionRepository.java
+++ b/core/src/main/java/com/foodielog/server/mention/repository/MentionRepository.java
@@ -1,7 +1,16 @@
 package com.foodielog.server.mention.repository;
 
 import com.foodielog.server.mention.entity.Mention;
+import com.foodielog.server.reply.entity.Reply;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface MentionRepository extends JpaRepository<Mention, Long> {
+
+    @Query("SELECT m FROM Mention m " +
+            "JOIN FETCH m.mentionedUser " +
+            "WHERE m.reply = :reply ")
+    List<Mention> findByReply(Reply reply);
 }

--- a/core/src/main/java/com/foodielog/server/mention/repository/MentionRepository.java
+++ b/core/src/main/java/com/foodielog/server/mention/repository/MentionRepository.java
@@ -1,0 +1,7 @@
+package com.foodielog.server.mention.repository;
+
+import com.foodielog.server.mention.entity.Mention;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MentionRepository extends JpaRepository<Mention, Long> {
+}

--- a/core/src/main/java/com/foodielog/server/notification/type/NotificationType.java
+++ b/core/src/main/java/com/foodielog/server/notification/type/NotificationType.java
@@ -6,7 +6,8 @@ import lombok.AllArgsConstructor;
 public enum NotificationType {
     REPLY("댓글"),
     LIKE("좋아요"),
-    FOLLOW("팔로우");
+    FOLLOW("팔로우"),
+    MENTION("멘션");
 
     private final String label;
 }


### PR DESCRIPTION
## 요약
댓글에 멘션 기능 추가

## 작업 내용
- [x] 댓글 작성 시 멘션 생성
- [x]  멘션 알림 생성
- [x]  댓글 조회 시 멘션 정보 리턴

## 참고 사항
### 1. 쿼리 관련 사항 
댓글 리스트 조회 시 자식 댓글 리스트를 받아오는 것 처럼 멘션 리스트로 받아오려고 했으나 
Hibernate MultipleBagFetchException 발생 

```
Hibernate는 기본적으로 성능 최적화를 위해 쿼리 실행 시 필요한 데이터만 가져옵니다. 
하지만 두 개 이상의 컬렉션을 동시에 가져오려고 하면 MultipleBagFetchException 오류가 발생할 수 있습니다.
```

때문에 댓글+자식 댓글 까지는 패치 조인으로 한번에 가져오고 
멘션 리스트는 따로 가져오도록 구현하였습니다 

멘션을 가지는지 그 여부를 reply가 가지고 있는다면 불필요한 select 쿼리를 줄일 수 있지 않을까 생각은 합니다...
(지금은 댓글의 수 만큼  mention_tb에 select 가 전송되고 있기 때문)

### 2. FCM 알림 관련 사항 
아직 알림 플래그가 수정이 안됐기 때문에 Notification 저장만 하고 FCM 알림 생성은 작성하지 않았습니다 

## 관련 이슈
Close #248
