### PR TITLE
[fix] #243 댓글 리스트 쿼리에서 대댓글 상태 체크 추가

### DIFF
--- a/core/src/main/java/com/foodielog/server/reply/repository/ReplyRepository.java
+++ b/core/src/main/java/com/foodielog/server/reply/repository/ReplyRepository.java
@@ -24,10 +24,10 @@ public interface ReplyRepository extends JpaRepository<Reply, Long> {
             "JOIN FETCH r.user " +
             "LEFT JOIN FETCH r.children c " +
             "LEFT JOIN FETCH c.user cu " +
-            "WHERE r.feed.id = :feedId AND r.parent = NULL AND r.status = 'NORMAL' AND r.id > :last " +
+            "WHERE r.feed.id = :feedId AND r.parent = NULL AND " +
+            "r.status = 'NORMAL' AND c.status = 'NORMAL' AND r.id > :last " +
             "ORDER BY r.id ASC, c.id ASC")
-    List<Reply> getReplyList(@Param("feedId") Long feedId, @Param("last") Long last,
-                             Pageable pageable);
+    List<Reply> getReplyList(@Param("feedId") Long feedId, @Param("last") Long last, Pageable pageable);
 
     Long countByFeedAndStatus(Feed feed, ContentStatus status);
 


### PR DESCRIPTION
## 요약
댓글 리스트 응답 시 자식 댓글들의 상태 체크를 하지 않아 
대댓글 삭제가 안된 것으로 나타남 

## 작업 내용
- 자식 댓글의 status가 normal인지 체크하는 쿼리 추가 

## 참고 사항

## 관련 이슈
#243 
